### PR TITLE
🔧 Boyd study changes

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,4 @@ pytest-cache==1.0
 pytest-cov==2.5.1
 pytest-pep8==1.0.6
 requests_mock==1.5.2
-moto==1.3.5
+moto==1.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-dateutil==2.7.3
 pytz==2018.5
 PyYAML==3.13
 six==1.11.0
-boto3==1.8.0
+boto3==1.9.51
 networkx==2.1
 xlrd==1.1.0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,9 @@ import shutil
 import pytest
 
 
-from kf_lib_data_ingest.etl.configuration.target_api_config import TargetAPIConfig
+from kf_lib_data_ingest.etl.configuration.target_api_config import (
+    TargetAPIConfig
+)
 from kf_lib_data_ingest.etl.ingest_pipeline import DataIngestPipeline
 TEST_ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 TEST_DATA_DIR = os.path.join(TEST_ROOT_DIR, 'data')

--- a/tests/data/test_boyd_study/extract_configs/manifest_180917_rectified_map.py
+++ b/tests/data/test_boyd_study/extract_configs/manifest_180917_rectified_map.py
@@ -1,6 +1,8 @@
 from kf_lib_data_ingest.common import constants
 from kf_lib_data_ingest.etl.extract.operations import *
-from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import CONCEPT
+from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import (
+    CONCEPT
+)
 
 source_data_url = (
     's3://kf-study-us-east-1-prd-sd-p445achv/study-files/modified/'
@@ -15,11 +17,11 @@ operations = [
         out_col=CONCEPT.SEQUENCING.LIBRARY_NAME
     ),
     keep_map(
-        in_col='combined',
+        in_col='Sample Name',
         out_col=CONCEPT.BIOSPECIMEN.ALIQUOT_ID
     ),
     keep_map(
-        in_col='combined',
+        in_col='Sample Name',
         out_col=CONCEPT.BIOSPECIMEN.ID
     )
 ]

--- a/tests/data/test_boyd_study/extract_configs/s3_files_kf-seq-data-hudsonalpha_haib17SB5136_map.py
+++ b/tests/data/test_boyd_study/extract_configs/s3_files_kf-seq-data-hudsonalpha_haib17SB5136_map.py
@@ -1,6 +1,8 @@
 from kf_lib_data_ingest.common import constants
 from kf_lib_data_ingest.etl.extract.operations import *
-from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import CONCEPT
+from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import (
+    CONCEPT
+)
 
 source_data_url = (
     's3://kf-study-us-east-1-prd-sd-p445achv/study-files/modified/'

--- a/tests/data/test_study/extract_configs/simple_tsv_example1.py
+++ b/tests/data/test_study/extract_configs/simple_tsv_example1.py
@@ -1,6 +1,8 @@
 from kf_lib_data_ingest.common import constants
 from kf_lib_data_ingest.etl.extract.operations import *
-from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import CONCEPT
+from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import (
+    CONCEPT
+)
 
 source_data_url = 'file://../data/simple_headered_tsv_1.tsv'
 

--- a/tests/data/test_study/extract_configs/simple_tsv_example2.py
+++ b/tests/data/test_study/extract_configs/simple_tsv_example2.py
@@ -1,6 +1,8 @@
 from kf_lib_data_ingest.common import constants
 from kf_lib_data_ingest.etl.extract.operations import *
-from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import CONCEPT
+from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import (
+    CONCEPT
+)
 
 source_data_url = 'file://../data/simple_headered_tsv_2.tsv'
 

--- a/tests/data/test_study/extract_configs/unsimple_xlsx_example1.py
+++ b/tests/data/test_study/extract_configs/unsimple_xlsx_example1.py
@@ -1,6 +1,8 @@
 from kf_lib_data_ingest.common import constants
 from kf_lib_data_ingest.etl.extract.operations import *
-from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import CONCEPT
+from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import (
+    CONCEPT
+)
 
 source_data_url = 'file://../data/unsimple_xlsx_1.xlsx'
 

--- a/tests/test_extract_stage.py
+++ b/tests/test_extract_stage.py
@@ -6,7 +6,9 @@ import pytest
 from conftest import TEST_DATA_DIR
 from kf_lib_data_ingest.common.misc import intsafe_str
 from kf_lib_data_ingest.etl.extract.extract import ExtractStage
-from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import CONCEPT
+from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import (
+    CONCEPT
+)
 
 study_1 = os.path.join(TEST_DATA_DIR, 'test_study')
 expected_results = {

--- a/tests/test_target_api_config.py
+++ b/tests/test_target_api_config.py
@@ -5,8 +5,12 @@ import pytest
 
 from conftest import TEST_ROOT_DIR
 
-from kf_lib_data_ingest.etl.configuration.target_api_config import TargetAPIConfig
-from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import CONCEPT
+from kf_lib_data_ingest.etl.configuration.target_api_config import (
+    TargetAPIConfig
+)
+from kf_lib_data_ingest.etl.transform.standard_model.concept_schema import (
+    CONCEPT
+)
 KIDS_FIRST_CONFIG = os.path.join(os.path.dirname(TEST_ROOT_DIR),
                                  'kf_lib_data_ingest',
                                  'target_apis', 'kids_first.py')


### PR DESCRIPTION
New analysis revealed the proper way to interpret their manifest file which shows that they released new specimens without updating the IDs in their data file.

This is an interesting change, because it pulls in data from a second file in order to adjust values in the first.

I'm also updating the moto and boto3 dependencies because for some reason I keep getting incompatibility errors with the previous pinned versions. 