### PR TITLE
♻️ Minor refactor transform, load

### DIFF
--- a/kf_lib_data_ingest/etl/ingest_pipeline.py
+++ b/kf_lib_data_ingest/etl/ingest_pipeline.py
@@ -100,7 +100,7 @@ class DataIngestPipeline(object):
         self.stage_dict['e'] = (ExtractStage,
                                 extract_cache_dir,
                                 self.data_ingest_config.extract_config_paths)
-        self.stage_dict['t'] = (TransformStage, )
+        self.stage_dict['t'] = (TransformStage, target_api_config_path)
 
         self.stage_dict['l'] = (
             LoadStage, target_api_config_path,

--- a/kf_lib_data_ingest/etl/load/load.py
+++ b/kf_lib_data_ingest/etl/load/load.py
@@ -37,17 +37,11 @@ class LoadStage(IngestStage):
         # previously produced at the end of stage run
         pass  # TODO
 
-    def _adapt(self, standard_model):
-        entity = {}
-        # TODO: will use the target schema and standard model to yield entities
-        # to load into the dataservice
-        return entity
-
     def _load(self, thing):
         # TODO: put the thing into the server (does the sending)
         pass
 
-    def _validate_run_parameters(self, standard_model):
+    def _validate_run_parameters(self, target_entities):
         # Should raise a InvalidIngestStageParameters if any
         # parameters are missing.
         # raise InvalidIngestStageParameters
@@ -56,7 +50,8 @@ class LoadStage(IngestStage):
         # class
         pass
 
-    def _run(self, standard_model):
+    def _run(self, target_entities):
         # TODO: revisit maybe?
-        for entity in self._adapt(standard_model):
-            self._load(entity)
+        for entity_type, entities in target_entities.items():
+            for entity in entities:
+                self._load(entity)

--- a/kf_lib_data_ingest/etl/transform/transform.py
+++ b/kf_lib_data_ingest/etl/transform/transform.py
@@ -10,13 +10,15 @@ from kf_lib_data_ingest.common.type_safety import (
     assert_all_safe_type
 )
 from kf_lib_data_ingest.etl.transform.standard_model.model import StandardModel
+from kf_lib_data_ingest.etl.configuration.target_api_config import (
+    TargetAPIConfig
+)
 
 
 class TransformStage(IngestStage):
-    def __init__(self):
+    def __init__(self, target_api_config_path):
         super().__init__()
-        # TODO we dont know what this takes yet
-        pass
+        self.target_api_config = TargetAPIConfig(target_api_config_path)
 
     def _read_output(self):
         # An ingest stage is responsible for serializing the data that is
@@ -60,13 +62,19 @@ class TransformStage(IngestStage):
 
     def _run(self, data_dict):
         """
-        Transform the tabular mapped data into a unified standard form
+        Transform the tabular mapped data into a unified standard form,
+        then transform again from the standard form into a dict of lists.
+        Keys are target entity types and values are lists of target entity
+        dicts.
 
         :param data_dict: a dict containing the mapped source data which
         follows the format outlined in _validate_run_parameters.
         """
-
+        # Insert mapped dataframes into the standard model
         model = StandardModel(logger=self.logger)
         model.populate(data_dict)
 
-        return model
+        # Transform the concept graph into target entities
+        target_entities = model.transform(self.target_api_config)
+
+        return target_entities

--- a/tests/test_standard_model.py
+++ b/tests/test_standard_model.py
@@ -123,103 +123,103 @@ def random_model(random_data_df_dict):
     return model
 
 
-# def test_populate_model(data_df_dict):
-#     """
-#     Test populating the concept graph in the standard model
-#     """
-#     model = StandardModel()
-#     model.populate(data_df_dict)
-#
-#     cg = model.concept_graph
-#
-#     # Check graph
-#     for extract_config_url, (source_file_url, df) in data_df_dict.items():
-#         for c, col in enumerate(df.columns):
-#             for r, value in enumerate(df[col]):
-#                 key = f'{col}|{value}'
-#                 node = cg.get_node(key)
-#                 if value is None:
-#                     assert not node
-#                     continue
-#                 # Node exists
-#                 assert node
-#                 # Node has non null value
-#                 assert pd.notnull(node.value)
-#                 # Node has a uid
-#                 assert node.uid
-#                 # Pedigree file was inserted into graph first so uid of
-#                 # participant nodes should contain pointers to participants
-#                 # from the pedigree file
-#                 if node.key.startswith(CONCEPT.PARTICIPANT.UNIQUE_KEY):
-#                     assert 'pedigree' in node.uid
-#                 # Subject sample file was inserted into graph second so uid of
-#                 # biospecimen nodes should contain pointers to biospecimens
-#                 # from the subject sample file
-#                 elif node.key.startswith(CONCEPT.BIOSPECIMEN.UNIQUE_KEY):
-#                     assert 'subject_sample' in node.uid
+def test_populate_model(data_df_dict):
+    """
+    Test populating the concept graph in the standard model
+    """
+    model = StandardModel()
+    model.populate(data_df_dict)
+
+    cg = model.concept_graph
+
+    # Check graph
+    for extract_config_url, (source_file_url, df) in data_df_dict.items():
+        for c, col in enumerate(df.columns):
+            for r, value in enumerate(df[col]):
+                key = f'{col}|{value}'
+                node = cg.get_node(key)
+                if value is None:
+                    assert not node
+                    continue
+                # Node exists
+                assert node
+                # Node has non null value
+                assert pd.notnull(node.value)
+                # Node has a uid
+                assert node.uid
+                # Pedigree file was inserted into graph first so uid of
+                # participant nodes should contain pointers to participants
+                # from the pedigree file
+                if node.key.startswith(CONCEPT.PARTICIPANT.UNIQUE_KEY):
+                    assert 'pedigree' in node.uid
+                # Subject sample file was inserted into graph second so uid of
+                # biospecimen nodes should contain pointers to biospecimens
+                # from the subject sample file
+                elif node.key.startswith(CONCEPT.BIOSPECIMEN.UNIQUE_KEY):
+                    assert 'subject_sample' in node.uid
 
 
-# def test_transform_all(target_api_config, random_model):
-#     """
-#     Test transformation when a list of target_concepts isn't supplied
-#     """
-#     # Test transform all concepts
-#     # Output should only include the concepts for which there is data
-#     data = random_model.transform(target_api_config,
-#                                   target_concepts_to_transform=None)
-#     all_target_concepts = target_api_config.concept_schemas.keys()
-#     target_concepts_w_data = ['family', 'participant', 'biospecimen']
-#
-#     for target_concept, output in data.items():
-#         if target_concept in target_concepts_w_data:
-#             assert len(output) > 0
-#         else:
-#             assert len(output) == 0
-#
-#     # All target concepts should be in output
-#     assert len(all_target_concepts) == len(data.keys())
-#
-#
-# def test_transform(target_api_config, random_model):
-#     """
-#     Test transformation from the standard model to a target model
-#     """
-#     # Transform to target model
-#     target_concepts = ['family', 'participant', 'biospecimen', 'mammals',
-#                        'phenotype']
-#     data = random_model.transform(target_api_config, target_concepts)
-#
-#     # Output should only contain instances of valid target concept types
-#     # (the ones we supplied that exist in target api config)
-#     diff = set(target_concepts).symmetric_difference(data.keys())
-#     assert (len(diff) == 1) and ('mammals' in diff)
-#
-#     # Number of output instances for a particular concept should match number
-#     # of id nodes for that concept in the concept graph
-#     for target_concept, instances in data.items():
-#         # Get standard concept this target concept maps to
-#         schema = target_api_config.concept_schemas[target_concept]
-#         standard_concept = schema['standard_concept']._CONCEPT_NAME
-#
-#         # Check counts
-#         expected_count = 0
-#         nodes = random_model.concept_graph.id_index.get(standard_concept)
-#         if nodes:
-#             expected_count = len(nodes)
-#         assert expected_count == len(instances)
-#
-#         # Check content
-#         for instance in instances:
-#             assert instance['id']
-#             if target_concept == 'participant':
-#                 assert instance['properties']['race'] is not None
-#             if target_concept == 'biospecimen':
-#                 assert instance['properties']['composition'] is not None
-#
-#     # There should be 0 phenotypes since we have no phenotype data
-#     assert 0 == len(data['phenotype'])
-#
-#
+def test_transform_all(target_api_config, random_model):
+    """
+    Test transformation when a list of target_concepts isn't supplied
+    """
+    # Test transform all concepts
+    # Output should only include the concepts for which there is data
+    data = random_model.transform(target_api_config,
+                                  target_concepts_to_transform=None)
+    all_target_concepts = target_api_config.concept_schemas.keys()
+    target_concepts_w_data = ['family', 'participant', 'biospecimen']
+
+    for target_concept, output in data.items():
+        if target_concept in target_concepts_w_data:
+            assert len(output) > 0
+        else:
+            assert len(output) == 0
+
+    # All target concepts should be in output
+    assert len(all_target_concepts) == len(data.keys())
+
+
+def test_transform(target_api_config, random_model):
+    """
+    Test transformation from the standard model to a target model
+    """
+    # Transform to target model
+    target_concepts = ['family', 'participant', 'biospecimen', 'mammals',
+                       'phenotype']
+    data = random_model.transform(target_api_config, target_concepts)
+
+    # Output should only contain instances of valid target concept types
+    # (the ones we supplied that exist in target api config)
+    diff = set(target_concepts).symmetric_difference(data.keys())
+    assert (len(diff) == 1) and ('mammals' in diff)
+
+    # Number of output instances for a particular concept should match number
+    # of id nodes for that concept in the concept graph
+    for target_concept, instances in data.items():
+        # Get standard concept this target concept maps to
+        schema = target_api_config.concept_schemas[target_concept]
+        standard_concept = schema['standard_concept']._CONCEPT_NAME
+
+        # Check counts
+        expected_count = 0
+        nodes = random_model.concept_graph.id_index.get(standard_concept)
+        if nodes:
+            expected_count = len(nodes)
+        assert expected_count == len(instances)
+
+        # Check content
+        for instance in instances:
+            assert instance['id']
+            if target_concept == 'participant':
+                assert instance['properties']['race'] is not None
+            if target_concept == 'biospecimen':
+                assert instance['properties']['composition'] is not None
+
+    # There should be 0 phenotypes since we have no phenotype data
+    assert 0 == len(data['phenotype'])
+
+
 @pytest.mark.parametrize('node_concept,neighbor_key,expected_output',
                          [
                              # Study, Family F1
@@ -264,115 +264,113 @@ def test_is_neighbor_valid(target_api_config, model, node_concept,
     assert g._is_neighbor_valid(node_concept, neighbor, rg) == expected_output
 
 
-# @pytest.mark.parametrize('id_node_key,concept_attr,expected_output',
-#                          [
-#                              # Participant P1, Race
-#                              (f'{CONCEPT.PARTICIPANT.UNIQUE_KEY}{DELIMITER}P1',
-#                               CONCEPT.PARTICIPANT.RACE, RACE.ASIAN),
-#
-#                              # Participant P2, Race
-#                              (f'{CONCEPT.PARTICIPANT.UNIQUE_KEY}{DELIMITER}P2',
-#                                  CONCEPT.PARTICIPANT.RACE, RACE.WHITE),
-#
-#                              # Biospecimen B1, Tissue type
-#                              (f'{CONCEPT.BIOSPECIMEN.UNIQUE_KEY}{DELIMITER}B1',
-#                                  CONCEPT.BIOSPECIMEN.TISSUE_TYPE, None)
-#                          ]
-#                          )
-# def test_find_attribute_value(target_api_config, model, id_node_key,
-#                               concept_attr, expected_output):
-#
-#     g = model.concept_graph
-#     rg = target_api_config.relationship_graph
-#
-#     # Test find concept attribute value
-#     start_node = g.get_node(id_node_key)
-#     assert g.find_attribute_value(start_node,
-#                                   concept_attr,
-#                                   rg) == expected_output
-#
-#
-# def test_find_non_existent(target_api_config, model):
-#     """
-#     Test that find for a start node that does not exist in the concept graph
-#
-#     ... this should theoretically never happen since the calling code can
-#     never pass in a non-existent start node. But testing for completeness...
-#     """
-#     # Create a non-existent node
-#     start_node = ConceptNode(CONCEPT.PARTICIPANT.UNIQUE_KEY, 'PH1')
-#     concept_attr = CONCEPT.PHENOTYPE.NAME
-#
-#     g = model.concept_graph
-#     rg = target_api_config.relationship_graph
-#
-#     # Test find concept attribute value
-#     with pytest.raises(ValueError) as e:
-#         g.find_attribute_value(start_node, concept_attr, rg)
-#         assert start_node.key in e
-#
-#
-# def test_general_find(target_api_config, random_data_df_dict):
-#     """
-#     For each concept in random_data_df_dict, for each attribute of the concept,
-#     verify that the correct value for the attribute is found in the
-#     concept graph.
-#     """
-#     # Populate standard model with random_data_df_dict data
-#     model = StandardModel()
-#     model.populate(random_data_df_dict)
-#     g = model.concept_graph
-#     rg = target_api_config.relationship_graph
-#
-#     df = [tup[1] for tup in random_data_df_dict.values()][0]
-#
-#     # Run tests
-#     concepts = {concept_from(col) for col in df.columns}
-#     links = {
-#         CONCEPT.PARTICIPANT._CONCEPT_NAME: {CONCEPT.FAMILY.UNIQUE_KEY},
-#         CONCEPT.BIOSPECIMEN._CONCEPT_NAME: {CONCEPT.PARTICIPANT.UNIQUE_KEY}
-#     }
-#     # For each concept in source table
-#     for concept in concepts:
-#         # Get the attribute columns for the concept
-#         attr_cols = [col for col in df.columns
-#                      if not is_identifier(col) and col.startswith(concept)]
-#         # For each row in the source table
-#         for _, row in df.iterrows():
-#             # Get the node from the graph pertaining to the concept ID
-#             id_col = f'{concept}{DELIMITER}UNIQUE_KEY'
-#             _id = row[id_col]
-#             node = g.get_node(f'{id_col}{DELIMITER}{_id}')
-#             # For each attribute of the concept instance, verify the value
-#             # found from the graph matches the value in the source data
-#             for attr in attr_cols:
-#                 value = g.find_attribute_value(node, attr, rg)
-#                 assert value == row[attr]
-#             for link in links.get(concept, []):
-#                 value = g.find_attribute_value(node, link, rg)
-#                 assert value == row[link]
-#
-#
-# def test_gml_import_export(tmpdir_factory, model):
-#     """
-#     Test etl.transform.standard_model.graph.export_to_gml and
-#     etl.transform.standard_model.graph.import_from_gml
-#     """
-#     fn = tmpdir_factory.mktemp("data").join("graph.gml")
-#     export_to_gml(model.concept_graph, str(fn))
-#
-#     assert os.path.isfile(fn)
-#
-#     imported_graph = import_from_gml(str(fn))
-#
-#     for node_key in model.concept_graph.graph.nodes:
-#         orig_node = model.concept_graph.graph.node.get(node_key)
-#         node = imported_graph.node.get(node_key)
-#         assert node
-#         assert (ConceptNode.to_dict(node['object']) ==
-#                 ConceptNode.to_dict(orig_node['object']))
-#
-#
+@pytest.mark.parametrize('id_node_key,concept_attr,expected_output',
+                         [
+                             # Participant P1, Race
+                             (f'{CONCEPT.PARTICIPANT.UNIQUE_KEY}{DELIMITER}P1',
+                              CONCEPT.PARTICIPANT.RACE, RACE.ASIAN),
+
+                             # Participant P2, Race
+                             (f'{CONCEPT.PARTICIPANT.UNIQUE_KEY}{DELIMITER}P2',
+                                 CONCEPT.PARTICIPANT.RACE, RACE.WHITE),
+
+                             # Biospecimen B1, Tissue type
+                             (f'{CONCEPT.BIOSPECIMEN.UNIQUE_KEY}{DELIMITER}B1',
+                                 CONCEPT.BIOSPECIMEN.TISSUE_TYPE, None)
+                         ]
+                         )
+def test_find_attribute_value(target_api_config, model, id_node_key,
+                              concept_attr, expected_output):
+
+    g = model.concept_graph
+    rg = target_api_config.relationship_graph
+
+    # Test find concept attribute value
+    start_node = g.get_node(id_node_key)
+    assert g.find_attribute_value(start_node,
+                                  concept_attr,
+                                  rg) == expected_output
+
+
+def test_find_non_existent(target_api_config, model):
+    """
+    Test that find for a start node that does not exist in the concept graph
+
+    ... this should theoretically never happen since the calling code can
+    never pass in a non-existent start node. But testing for completeness...
+    """
+    # Create a non-existent node
+    start_node = ConceptNode(CONCEPT.PARTICIPANT.UNIQUE_KEY, 'PH1')
+    concept_attr = CONCEPT.PHENOTYPE.NAME
+
+    g = model.concept_graph
+    rg = target_api_config.relationship_graph
+
+    # Test find concept attribute value
+    with pytest.raises(ValueError) as e:
+        g.find_attribute_value(start_node, concept_attr, rg)
+        assert start_node.key in e
+
+
+def test_general_find(target_api_config, random_data_df_dict):
+    """
+    For each concept in random_data_df_dict, for each attribute of the concept,
+    verify that the correct value for the attribute is found in the
+    concept graph.
+    """
+    # Populate standard model with random_data_df_dict data
+    model = StandardModel()
+    model.populate(random_data_df_dict)
+    g = model.concept_graph
+    rg = target_api_config.relationship_graph
+
+    df = [tup[1] for tup in random_data_df_dict.values()][0]
+
+    # Run tests
+    concepts = {concept_from(col) for col in df.columns}
+    links = {
+        CONCEPT.PARTICIPANT._CONCEPT_NAME: {CONCEPT.FAMILY.UNIQUE_KEY},
+        CONCEPT.BIOSPECIMEN._CONCEPT_NAME: {CONCEPT.PARTICIPANT.UNIQUE_KEY}
+    }
+    # For each concept in source table
+    for concept in concepts:
+        # Get the attribute columns for the concept
+        attr_cols = [col for col in df.columns
+                     if not is_identifier(col) and col.startswith(concept)]
+        # For each row in the source table
+        for _, row in df.iterrows():
+            # Get the node from the graph pertaining to the concept ID
+            id_col = f'{concept}{DELIMITER}UNIQUE_KEY'
+            _id = row[id_col]
+            node = g.get_node(f'{id_col}{DELIMITER}{_id}')
+            # For each attribute of the concept instance, verify the value
+            # found from the graph matches the value in the source data
+            for attr in attr_cols:
+                value = g.find_attribute_value(node, attr, rg)
+                assert value == row[attr]
+            for link in links.get(concept, []):
+                value = g.find_attribute_value(node, link, rg)
+                assert value == row[link]
+
+
+def test_gml_import_export(tmpdir_factory, model):
+    """
+    Test etl.transform.standard_model.graph.export_to_gml and
+    etl.transform.standard_model.graph.import_from_gml
+    """
+    fn = tmpdir_factory.mktemp("data").join("graph.gml")
+    export_to_gml(model.concept_graph, str(fn))
+
+    assert os.path.isfile(fn)
+
+    imported_graph = import_from_gml(str(fn))
+
+    for node_key in model.concept_graph.graph.nodes:
+        orig_node = model.concept_graph.graph.node.get(node_key)
+        node = imported_graph.node.get(node_key)
+        assert node
+        assert (ConceptNode.to_dict(node['object']) ==
+                ConceptNode.to_dict(orig_node['object']))
 
 
 def test_unique_keys():

--- a/tests/test_transform_stage.py
+++ b/tests/test_transform_stage.py
@@ -9,11 +9,12 @@ import pandas as pd
 
 from kf_lib_data_ingest.etl.transform.transform import TransformStage
 from kf_lib_data_ingest.common.errors import InvalidIngestStageParameters
+from conftest import KIDS_FIRST_CONFIG
 
 
 def test_invalid_run_parameters():
 
-    stage = TransformStage()
+    stage = TransformStage(KIDS_FIRST_CONFIG)
 
     # Bad keys
     with pytest.raises(InvalidIngestStageParameters):


### PR DESCRIPTION
Part 1 of #95 

Previously the load stage was invoking a part of the transformation (from concept graph to target entities). We want to move this responsibility into the transformation stage and ensure that the load stage only deals with transmitting the target entities coming out of transform stage into the target service. 

This will allow us to interchange the transformation approach at runtime (auto transform via graph or guided transform via user supplied transform function).
