### PR TITLE
✨Add merge functions to pandas utils

### DIFF
--- a/kf_lib_data_ingest/common/pandas_utils.py
+++ b/kf_lib_data_ingest/common/pandas_utils.py
@@ -187,8 +187,10 @@ def outer_merge(df1, df2, with_merge_detail_dfs=True, **kwargs):
 
         both - a dataframe of rows that matched in both the left and right
         dataframes (equivalent to the df returned by an inner join)
-        left - a dataframe of rows that were ONLY in the left dataframe
-        right - a dataframe of rows that were ONLY in the right dataframe
+        left_only - a dataframe of rows that were ONLY in the left dataframe
+        right_only - a dataframe of rows that were ONLY in the right dataframe
+
+    See https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.merge.html # noqa
 
     :param df1: the left dataframe to be merged
     :type df1: Pandas.DataFrame
@@ -206,16 +208,14 @@ def outer_merge(df1, df2, with_merge_detail_dfs=True, **kwargs):
     outer = merge_wo_duplicates(df1, df2, **kwargs)
 
     if with_merge_detail_dfs:
-        both = outer[outer['_merge'] == 'both']
-        left = outer[outer['_merge'] == 'left_only']
-        right = outer[outer['_merge'] == 'right_only']
+        detail_dfs = [outer[outer['_merge'] == keyword]
+                      for keyword in ['both', 'left_only', 'right_only']]
 
-        for df in [outer, both, left, right]:
+        for df in [outer] + detail_dfs:
             df.drop(['_merge'], axis=1, inplace=True)
             df.dropna(how="all", inplace=True)
 
-        return outer, both, left, right
+        return outer, detail_dfs[0], detail_dfs[1], detail_dfs[2]
 
     else:
         return outer
-

--- a/kf_lib_data_ingest/common/pandas_utils.py
+++ b/kf_lib_data_ingest/common/pandas_utils.py
@@ -155,9 +155,9 @@ def merge_wo_duplicates(left, right, **kwargs):
     :type right: Pandas.DataFrame
     :param kwargs: keyword args expected by Pandas.merge function
     """
-    def resolve_duplicates(df):
-        l_suffix = '_x'
-        r_suffix = '_y'
+    def resolve_duplicates(df, suffixes):
+        l_suffix = suffixes[0]
+        r_suffix = suffixes[1]
 
         while True:
             to_del = set()
@@ -176,7 +176,7 @@ def merge_wo_duplicates(left, right, **kwargs):
 
     merged = pandas.merge(left, right, **kwargs)
 
-    return resolve_duplicates(merged)
+    return resolve_duplicates(merged, kwargs.pop('suffixes', ('_x', '_y')))
 
 
 def outer_merge(df1, df2, with_merge_detail_dfs=True, **kwargs):
@@ -212,8 +212,8 @@ def outer_merge(df1, df2, with_merge_detail_dfs=True, **kwargs):
                       for keyword in ['both', 'left_only', 'right_only']]
 
         for df in [outer] + detail_dfs:
-            df.drop(['_merge'], axis=1, inplace=True)
             df.dropna(how="all", inplace=True)
+            del df['_merge']
 
         return outer, detail_dfs[0], detail_dfs[1], detail_dfs[2]
 

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -3,9 +3,24 @@ Tests for kf_lib_data_ingest/common/pandas_utils.py
 """
 
 import pandas
+import numpy
 import pytest
 
 from kf_lib_data_ingest.common import pandas_utils
+
+
+@pytest.fixture(scope='function')
+def dfs():
+    nrows = 3
+    df1 = pandas.DataFrame({'A': [f'A{i}' for i in range(nrows)],
+                            'B': [f'B{i}' for i in range(nrows)],
+                            'C': [f'C{i}' for i in range(nrows)]})
+
+    df2 = df1.copy()
+    df2['B'] = 'foo'
+    df2['C'] = 'bar'
+
+    return [df1, df2]
 
 
 def test_try_pop():
@@ -39,3 +54,41 @@ def test_safe_pandas_replace_no_cascade():
     assert pandas_utils.safe_pandas_replace(
         pandas.Series(['1', '2', '3']), cascading_replace
     ).equals(pandas.Series(['2', '3', '4']))
+
+
+def test_merge_wo_duplicates(dfs):
+    df1 = dfs[0]
+    df2 = dfs[1]
+
+    # Test when all cols match
+    expected_df = df1.copy()
+    merged = pandas_utils.merge_wo_duplicates(df1, df2, on='A', how='outer')
+    assert merged.equals(expected_df)
+
+    # Test when NaNs result from outer merge
+    df2.at[2, 'A'] = 'bloo'
+    expected_df = df1.copy().append(df2.tail(1), ignore_index=True)
+    merged = pandas_utils.merge_wo_duplicates(df1, df2, on='A', how='outer')
+    assert merged.equals(expected_df)
+
+
+def test_outer_merge(dfs):
+    df1 = dfs[0]
+    df2 = dfs[1]
+    df2.at[2, 'A'] = 'bloo'
+
+    ret_val = pandas_utils.outer_merge(df1, df2, on='A')
+    merged, in_both, left_only, right_only = ret_val
+    expected = df1.copy().append(df2.tail(1), ignore_index=True)
+
+    assert len(ret_val) == 4
+    assert expected.equals(merged)
+    assert in_both.equals(df1.head(2))
+    assert left_only.equals(df1.tail(1))
+    assert numpy.array_equal(right_only.values, df2.tail(1).values)
+
+    df = pandas_utils.outer_merge(df1, df2, on='A',
+                                  with_merge_detail_dfs=False)
+    assert isinstance(df, pandas.DataFrame)
+    assert expected.equals(df)
+

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -65,6 +65,11 @@ def test_merge_wo_duplicates(dfs):
     merged = pandas_utils.merge_wo_duplicates(df1, df2, on='A', how='outer')
     assert merged.equals(expected_df)
 
+    # Same as above, but with custom suffixes
+    merged = pandas_utils.merge_wo_duplicates(
+        df1, df2, on='A', how='outer', suffixes=('__left__', '__right__'))
+    assert merged.equals(expected_df)
+
     # Test when NaNs result from outer merge
     df2.at[2, 'A'] = 'bloo'
     expected_df = df1.copy().append(df2.tail(1), ignore_index=True)
@@ -91,4 +96,3 @@ def test_outer_merge(dfs):
                                   with_merge_detail_dfs=False)
     assert isinstance(df, pandas.DataFrame)
     assert expected.equals(df)
-


### PR DESCRIPTION
Would like to have this merged before #101 , so that I can use these functions when writing and testing the user defined transform functions.

- Add `merge_wo_duplicates`, merge two dataframes into a single dataframe with no duplicate columns. Slightly modified version of [this](https://github.com/kids-first/kf-study-imports/blob/1429f8b538cb60fe47174cc7025daf219432f7f5/Avi/pandas_utils.py#L54)

- Add `outer_merge`, outer merge two dataframes and optionally return debugging dataframes