### PR TITLE
♻️ Refactor stage read write

### DIFF
--- a/kf_lib_data_ingest/common/stage.py
+++ b/kf_lib_data_ingest/common/stage.py
@@ -8,11 +8,13 @@ from functools import wraps
 class IngestStage(ABC):
 
     def __init__(self, ingest_output_dir=None):
-        self.ingest_output_dir = ingest_output_dir or (
-            os.path.join(os.getcwd(), 'output')
-        )
-        self.stage_cache_dir = os.path.join(self.ingest_output_dir,
-                                            type(self).__name__)
+        self.ingest_output_dir = ingest_output_dir
+        if self.ingest_output_dir:
+            self.stage_cache_dir = os.path.join(self.ingest_output_dir,
+                                                type(self).__name__)
+        else:
+            self.stage_cache_dir = None
+
         self.logger = logging.getLogger(type(self).__name__)
 
     @abstractmethod
@@ -89,7 +91,8 @@ class IngestStage(ABC):
         output = self._run(*args, **kwargs)
 
         # Write output of stage to disk
-        os.makedirs(self.stage_cache_dir, exist_ok=True)
-        self._write_output(output)
+        if self.stage_cache_dir:
+            os.makedirs(self.stage_cache_dir, exist_ok=True)
+            self._write_output(output)
 
         return output

--- a/kf_lib_data_ingest/common/stage.py
+++ b/kf_lib_data_ingest/common/stage.py
@@ -7,8 +7,12 @@ from functools import wraps
 
 class IngestStage(ABC):
 
-    def __init__(self, stage_cache_dir=None):
-        self.stage_cache_dir = stage_cache_dir
+    def __init__(self, ingest_output_dir=None):
+        self.ingest_output_dir = ingest_output_dir or (
+            os.path.join(os.getcwd(), 'output')
+        )
+        self.stage_cache_dir = os.path.join(self.ingest_output_dir,
+                                            type(self).__name__)
         self.logger = logging.getLogger(type(self).__name__)
 
     @abstractmethod
@@ -85,6 +89,7 @@ class IngestStage(ABC):
         output = self._run(*args, **kwargs)
 
         # Write output of stage to disk
+        os.makedirs(self.stage_cache_dir, exist_ok=True)
         self._write_output(output)
 
         return output

--- a/kf_lib_data_ingest/etl/ingest_pipeline.py
+++ b/kf_lib_data_ingest/etl/ingest_pipeline.py
@@ -29,6 +29,10 @@ class DataIngestPipeline(object):
         """
         self.data_ingest_config = DatasetIngestConfig(
             dataset_ingest_config_path)
+        self.ingest_config_dir = os.path.dirname(
+            self.data_ingest_config.config_filepath)
+        self.ingest_output_dir = os.path.join(self.ingest_config_dir,
+                                              'output')
 
     def run(self, target_api_config_path, auto_transform=False,
             use_async=False, target_url=DEFAULT_TARGET_URL):
@@ -94,14 +98,9 @@ class DataIngestPipeline(object):
         # Create an ordered dict of all ingest stages and their parameters
         self.stage_dict = OrderedDict()
 
-        ingest_config_dir = os.path.dirname(
-            self.data_ingest_config.config_filepath)
-
         # Extract stage
-        extract_cache_dir = os.path.join(ingest_config_dir, 'output_cache')
-        os.makedirs(extract_cache_dir, exist_ok=True)
         self.stage_dict['e'] = (ExtractStage,
-                                extract_cache_dir,
+                                self.ingest_output_dir,
                                 self.data_ingest_config.extract_config_paths)
 
         # Transform stage
@@ -111,7 +110,7 @@ class DataIngestPipeline(object):
             transform_fp = self.data_ingest_config.transform_function_path
             if transform_fp:
                 transform_fp = os.path.join(
-                    ingest_config_dir, os.path.relpath(transform_fp))
+                    self.ingest_config_dir, os.path.relpath(transform_fp))
 
         self.stage_dict['t'] = (TransformStage, target_api_config_path,
                                 transform_fp)

--- a/tests/test_extract_stage.py
+++ b/tests/test_extract_stage.py
@@ -32,10 +32,8 @@ expected_results = {
 def test_extracts():
     for study_dir, study_configs in expected_results.items():
         extract_configs = list(study_configs.keys())
-        es = ExtractStage(study_dir, extract_configs)
+        es = ExtractStage(os.path.join(study_dir, 'output'), extract_configs)
         df_out = es.run()
-
-        es._write_output(df_out)
         recycled_output = es._read_output()
 
         for config in extract_configs:


### PR DESCRIPTION
This PR will standardize the structure of pipeline outputs.
-  Base `stage.py` handles creation of its output dir and names it using its class name. 

Output dir structure will be
```
<study dir>/
    output/
        <stage class name>/
            - output_1.tsv
            - output_2.txt
            - ...  
```

Current example: 
```
tests/data/test_study/
    output/
        ExtractStage/
            - ExtractStage_cache.txt
        TransformStage/
        LoadStage/ 
```