### PR TITLE
♻️✨ Extract serialize tables

### DIFF
--- a/kf_lib_data_ingest/etl/extract/extract.py
+++ b/kf_lib_data_ingest/etl/extract/extract.py
@@ -1,8 +1,8 @@
-import json
 import os
 from collections import defaultdict
 from functools import reduce
 from math import gcd
+from pprint import pformat
 
 import pandas
 
@@ -12,7 +12,11 @@ from kf_lib_data_ingest.common.file_retriever import (
     FileRetriever,
     split_protocol
 )
-from kf_lib_data_ingest.common.misc import intsafe_str
+from kf_lib_data_ingest.common.misc import (
+    intsafe_str,
+    write_json,
+    read_json
+)
 from kf_lib_data_ingest.common.stage import IngestStage
 from kf_lib_data_ingest.common.type_safety import function
 from kf_lib_data_ingest.etl.configuration.base_config import (
@@ -58,32 +62,53 @@ class ExtractStage(IngestStage):
     def _write_output(self, output):
         """
         Implements IngestStage._write_output
-        """
-        class IndexlessJSONEncoder(json.JSONEncoder):
-            def default(self, obj):
-                if hasattr(obj, 'to_dict'):
-                    no_index = obj.to_dict(orient='split')
-                    del no_index['index']
-                    return no_index
-                return json.JSONEncoder.default(self, obj)
 
-        with open(self._output_path(), "w") as fp:
-            json.dump(output, fp, cls=IndexlessJSONEncoder, indent=2)
+        Write dataframes to tsv files in the stage's output dir.
+        Write an JSON file that tracks metadata about the tsv files such as
+        the extract_config_url and source_url for each dataframe
+
+        :param output: the return from ExtractStage._run
+        :type output: dict
+        """
+        meta_fp = os.path.join(self.stage_cache_dir, 'metadata.json')
+        metadata = {}
+        for extract_config_url, (source_url, df) in output.items():
+            filename = os.path.basename(extract_config_url).split('.')[0]
+            filepath = os.path.join(self.stage_cache_dir, filename + '.tsv')
+            metadata[filepath] = {
+                'extract_config_url': extract_config_url,
+                'source_data_url': source_url
+            }
+            df.to_csv(filepath, sep='\t', index=False)
+
+        write_json(metadata, meta_fp)
+
+        self.logger.info(f'Writing {self.__class__.__name__} output:\n'
+                         f'{pformat(list(output.keys()))}')
 
     def _read_output(self):
         """
-        Implements IngestStage._read_output
-        """
-        data = {}
-        with open(self._output_path()) as fp:
-            data = json.load(fp)
+        Implements IngestStage._write_output
 
-        for k, v in data.items():
-            v[1] = pandas.DataFrame.from_records(
-                v[1]['data'],
-                columns=v[1]['columns']
+        Read the output files created by _write_output and reconstruct the
+        original output of ExtractStage._run.
+
+        :returns the original output of ExtractStage._run.
+        """
+        output = {}
+
+        meta_fp = os.path.join(self.stage_cache_dir, 'metadata.json')
+        metadata = read_json(meta_fp)
+
+        for filepath, info in metadata.items():
+            output[info['extract_config_url']] = (
+                info['source_data_url'],
+                pandas.read_csv(filepath, delimiter='\t')
             )
-        return data
+
+        self.logger.info(f'Reading {self.__class__.__name__} output:\n'
+                         f'{pformat(list(metadata.keys()))}')
+        return output
 
     def _validate_run_parameters(self):
         # Extract stage does not expect any args
@@ -105,8 +130,9 @@ class ExtractStage(IngestStage):
 
     def _run(self):
         """
-        :returns: A dictionary of all extracted dataframes keyed by extract
-            config paths
+        :returns: A dictionary where a key is the URL to the extract_config
+            that produced the dataframe and a value is a tuple of
+            (<URL to source data fle>, <extracted DataFrame>)
         """
         output = {}
         for extract_config in self.extract_configs:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,10 @@ def ingest_pipeline():
     if os.path.exists(p.data_ingest_config.log_dir):
         shutil.rmtree(p.data_ingest_config.log_dir)
 
+    # Delete the entire ingest outputs directory
+    if os.path.exists(p.ingest_output_dir):
+        shutil.rmtree(p.ingest_output_dir)
+
 
 @pytest.fixture(scope='function')
 def target_api_config():

--- a/tests/test_extract_stage.py
+++ b/tests/test_extract_stage.py
@@ -46,6 +46,11 @@ def test_extracts():
             assert sorted(expected.columns) == sorted(extracted.columns)
             expected = expected[extracted.columns]
 
+            # test serialize / deserialize equivalence
+            pandas.testing.assert_frame_equal(
+                expected, recycled_output[config][1]
+            )
+
             # account for datatype mismatches induced by loading the expected
             # result directly from a file
             for col in expected.columns:
@@ -54,8 +59,3 @@ def test_extracts():
 
             # test for expected equivalence
             pandas.testing.assert_frame_equal(extracted, expected)
-
-            # test serialize/deserialize equivalence
-            pandas.testing.assert_frame_equal(
-                extracted, recycled_output[config][1]
-            )


### PR DESCRIPTION
Closes #92 

Change extract serialization to emit a tsv file per extracted dataframe rather than a single txt file with JSON

Example dir structure:
```
├── test_study
│   ├── extract_configs
│   │   ├── simple_tsv_example1.py
│   │   ├── simple_tsv_example2.py
│   │   └── unsimple_xlsx_example1.py
│   ├── output
│   │   └── ExtractStage
│   │       ├── metadata.json
│   │       ├── simple_tsv_example1.tsv
│   │       ├── simple_tsv_example2.tsv
│   │       └── unsimple_xlsx_example1.tsv
```

metadata.json looks like this:
```json
{
    "/Users/singhn4/Projects/kids_first/kf-lib-data-ingest/tests/data/test_study/output/ExtractStage/simple_tsv_example1.tsv":{
        "extract_config_url":"/Users/singhn4/Projects/kids_first/kf-lib-data-ingest/tests/data/test_study/extract_configs/simple_tsv_example1.py",
        "source_data_url":"file:///Users/singhn4/Projects/kids_first/kf-lib-data-ingest/tests/data/test_study/data/simple_headered_tsv_1.tsv"
    },
    "/Users/singhn4/Projects/kids_first/kf-lib-data-ingest/tests/data/test_study/output/ExtractStage/simple_tsv_example2.tsv":{
        "extract_config_url":"/Users/singhn4/Projects/kids_first/kf-lib-data-ingest/tests/data/test_study/extract_configs/simple_tsv_example2.py",
        "source_data_url":"file:///Users/singhn4/Projects/kids_first/kf-lib-data-ingest/tests/data/test_study/data/simple_headered_tsv_2.tsv"
    },
    "/Users/singhn4/Projects/kids_first/kf-lib-data-ingest/tests/data/test_study/output/ExtractStage/unsimple_xlsx_example1.tsv":{
        "extract_config_url":"/Users/singhn4/Projects/kids_first/kf-lib-data-ingest/tests/data/test_study/extract_configs/unsimple_xlsx_example1.py",
        "source_data_url":"file:///Users/singhn4/Projects/kids_first/kf-lib-data-ingest/tests/data/test_study/data/unsimple_xlsx_1.xlsx"
    }
}
```