### PR TITLE
👷 Fix CI Scripts

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,9 @@
-codacy-coverage==1.3.10
-pytest==3.6.3
-pytest-cache==1.0
-pytest-cov==2.5.1
-pytest-codestyle==1.3.1
-requests_mock==1.5.2
+codacy-coverage==1.3.11
+ipaddress==1.0.22
 moto==1.3.7
-py2neo==4.1.0
+py2neo==4.2.0
+pyopenssl==19.0.0
+pytest-cache==1.0
+pytest-codestyle==1.4.0
+pytest-cov==2.6.1
+requests-mock==1.5.2

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,4 +1,3 @@
 sphinx==1.8.1
-sphinx_rtd_theme==0.4.2
 sphinx-autobuild==0.7.1
 -e git+https://github.com/kids-first/kf-sphinx-docs-theme.git#egg=kf-sphinx-docs-theme

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,6 +5,7 @@ set -e
 
 python3 -m venv venv
 . venv/bin/activate
+pip install --upgrade pip
 pip install -e .
 pip install -r dev-requirements.txt
 pip install -r doc-requirements.txt

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,6 +6,7 @@ set -e
 python3 -m venv venv
 . venv/bin/activate
 pip install --upgrade pip
+python setup.py install_egg_info
 pip install -e .
 pip install -r dev-requirements.txt
 pip install -r doc-requirements.txt

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort the script if there is a non-zero error
+set -e
+
 python3 -m venv venv
 . venv/bin/activate
 pip install -e .

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort the script if there is a non-zero error
+set -e
+
 . venv/bin/activate
 py.test --cov=kf_lib_data_ingest tests
 py.test --codestyle kf_lib_data_ingest

--- a/tests/test_file_retriever.py
+++ b/tests/test_file_retriever.py
@@ -65,6 +65,8 @@ def test_s3_file(s3_file, storage_dir, use_storage_dir, cleanup_at_exit,
     """
     Test file retrieval via s3
     """
+    os.environ.setdefault("AWS_ACCESS_KEY_ID", "foobar_key")
+    os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "foobar_secret")
     _test_get_file(s3_file, storage_dir, use_storage_dir, cleanup_at_exit,
                    should_file_exist)
 


### PR DESCRIPTION
- For all CI scripts, always abort on non-zero exit code from any of the things running in the script
- Upgrade pip and install egg info before installing reqs
    - See https://github.com/pypa/pip/issues/4537 for more details
- Fix recurring S3 related error in file retriever test

thanks @fiendish !