### PR TITLE
✨ Post-extract accounting

### DIFF
--- a/kf_lib_data_ingest/common/concept_schema.py
+++ b/kf_lib_data_ingest/common/concept_schema.py
@@ -155,6 +155,9 @@ def compile_schema():
     return property_paths
 
 
+str_to_CONCEPT = {}
+
+
 def _set_cls_attrs(node, prev_node, property_path, property_paths):
     """
     Recursive method to traverse a class hierarchy and set class attributes
@@ -201,8 +204,10 @@ def _set_cls_attrs(node, prev_node, property_path, property_paths):
         # The concept name path string if the attribute is _CONCEPT_NAME
         if node == '_CONCEPT_NAME':
             setattr(prev_node, node, concept_name_str)
+            str_to_CONCEPT[concept_name_str] = prev_node
         else:
             setattr(prev_node, node, property_path_str)
+
         # Add property string to list of property path strings
         property_paths.add(property_path_str)
 
@@ -336,14 +341,14 @@ def concept_from(concept_attribute_str):
     """
     Extract the concept from the concept attribute string
     """
-    return DELIMITER.join(concept_attribute_str.split(DELIMITER)[0:-1])
+    return concept_attribute_str.rsplit(DELIMITER, 1)[0]
 
 
 def concept_attr_from(concept_attribute_str):
     """
     Extract the concept attribute from the concept attribute string
     """
-    return concept_attribute_str.split(DELIMITER)[-1]
+    return concept_attribute_str.rsplit(DELIMITER, 1)[1]
 
 
 unique_key_composition = _create_unique_key_composition()

--- a/kf_lib_data_ingest/common/stage.py
+++ b/kf_lib_data_ingest/common/stage.py
@@ -47,6 +47,20 @@ class IngestStage(ABC):
     def _run(self, *args, **kwargs):
         pass
 
+    def _postrun_accounting(self, run_output):
+        """
+        Performs post-run accounting. Here is where we'll perform whichever
+        automatic data consistency checks we can do immediately after the
+        current stage is done. Checks that can only be comprehensively
+        performed after later stages will not happen here.
+
+        :param run_output: the output returned by the _run() method
+        :return: boolean True if all accounting checks passed, else False
+        :return: some meaningful data structure of what has been accounted
+        :return: a human-readable message string describing the accounting
+        """
+        return True, None, None
+
     @abstractmethod
     def _validate_run_parameters(self, *args, **kwargs):
         # Subclasses should raise a InvalidIngestStageParameters if any
@@ -119,4 +133,11 @@ class IngestStage(ABC):
         # Write output of stage to disk
         self.write_output(output)
 
-        return output
+        all_checks_passed, accounting_data, accounting_message = (
+            self._postrun_accounting(output)
+        )
+        self.logger.info(
+            f'{type(self).__name__} Accounting\n\n{accounting_message}\n'
+        )
+
+        return output, all_checks_passed, accounting_data

--- a/kf_lib_data_ingest/common/stage.py
+++ b/kf_lib_data_ingest/common/stage.py
@@ -47,17 +47,17 @@ class IngestStage(ABC):
     def _run(self, *args, **kwargs):
         pass
 
-    def _postrun_accounting(self, run_output):
+    def _postrun_analysis(self, run_output):
         """
-        Performs post-run accounting. Here is where we'll perform whichever
-        automatic data consistency checks we can do immediately after the
-        current stage is done. Checks that can only be comprehensively
-        performed after later stages will not happen here.
+        Performs post-run accounting and other analysis. Here is where we'll
+        perform whichever automatic data consistency checks we can do
+        immediately after the current stage is done. Checks that can only be
+        comprehensively performed after later stages will not happen here.
 
         :param run_output: the output returned by the _run() method
         :return: boolean True if all accounting checks passed, else False
         :return: some meaningful data structure of what has been accounted
-        :return: a human-readable message string describing the accounting
+        :return: a human-readable message string describing the analysis
         """
         return True, None, None
 
@@ -134,7 +134,7 @@ class IngestStage(ABC):
         self.write_output(output)
 
         all_checks_passed, accounting_data, accounting_message = (
-            self._postrun_accounting(output)
+            self._postrun_analysis(output)
         )
         self.logger.info(
             f'{type(self).__name__} Accounting\n\n{accounting_message}\n'

--- a/kf_lib_data_ingest/common/type_safety.py
+++ b/kf_lib_data_ingest/common/type_safety.py
@@ -141,6 +141,7 @@ def function(x):
     return inspect.isfunction(x) or inspect.isbuiltin(x)
 
 
+is_function = function  # simple alias for clarity
 _basic_types = {int, float, bool, str, bytes}
 
 

--- a/kf_lib_data_ingest/etl/configuration/dataset_ingest_config.py
+++ b/kf_lib_data_ingest/etl/configuration/dataset_ingest_config.py
@@ -54,6 +54,7 @@ class DatasetIngestConfig(YamlConfig):
         self.investigator = self.contents.get('investigator')
         self.target_service_entities = self.contents.get(
             'target_service_entities')
+        self.expected_counts = self.contents.get('expected_counts')
 
     def _set_log_params(self):
         """

--- a/kf_lib_data_ingest/etl/extract/extract.py
+++ b/kf_lib_data_ingest/etl/extract/extract.py
@@ -8,6 +8,7 @@ from pprint import pformat
 import pandas
 from tabulate import tabulate
 
+from kf_lib_data_ingest.common.concept_schema import str_to_CONCEPT
 from kf_lib_data_ingest.common.datafile_readers import read_excel_file
 from kf_lib_data_ingest.common.file_retriever import (
     PROTOCOL_SEP,
@@ -433,6 +434,18 @@ class ExtractStage(IngestStage):
                 columns=['key', 'expected', 'found', 'pass']
             )
             for key, expected in self.expected_counts.items():
+
+                # Accept both concepts and attributes, but automatically
+                # translate lone concepts as meaning id or else unique_key if
+                # one of those was discovered in the data.
+                if key not in counted:
+                    if key in str_to_CONCEPT:
+                        concept = str_to_CONCEPT[key]
+                        if concept.ID in counted:
+                            key = concept.ID
+                        elif concept.UNIQUE_KEY in counted:
+                            key = concept.UNIQUE_KEY
+
                 found = uniques.get(key)
                 if expected == found:
                     passed = '✅'

--- a/kf_lib_data_ingest/etl/extract/extract.py
+++ b/kf_lib_data_ingest/etl/extract/extract.py
@@ -387,9 +387,9 @@ class ExtractStage(IngestStage):
         # return dictionary of all dataframes keyed by extract config paths
         return output
 
-    def _postrun_accounting(self, run_output):
+    def _postrun_analysis(self, run_output):
         """
-        See the docstring for IngestStage._postrun_accounting.
+        See the docstring for IngestStage._postrun_analysis.
         """
         # Storage for where all of the values for each concept key are found
         # counted = {

--- a/kf_lib_data_ingest/etl/extract/extract.py
+++ b/kf_lib_data_ingest/etl/extract/extract.py
@@ -391,11 +391,15 @@ class ExtractStage(IngestStage):
     def _postrun_analysis(self, run_output):
         """
         See the docstring for IngestStage._postrun_analysis.
+
+        In ExtractStage._postrun_analysis we verify that we found as many
+        unique values of each attribute as we expected to find.
         """
-        # Storage for where all of the values for each concept key are found
+        # A dict where concept values map to a list of all source files
+        # containing them
         # counted = {
-        #     a_key: {
-        #         a1: [file1, file2],
+        #     a_key: {  # e.g. PARTICIPANT.ID
+        #         a1: [file1, file2],  # e.g. PARTICIPANT.ID a1 is in files 1&2
         #         ...
         #     },
         #     ...

--- a/kf_lib_data_ingest/etl/extract/extract.py
+++ b/kf_lib_data_ingest/etl/extract/extract.py
@@ -6,6 +6,7 @@ from math import gcd
 from pprint import pformat
 
 import pandas
+from tabulate import tabulate
 
 from kf_lib_data_ingest.common.datafile_readers import read_excel_file
 from kf_lib_data_ingest.common.file_retriever import (
@@ -20,13 +21,15 @@ from kf_lib_data_ingest.common.misc import (
 )
 from kf_lib_data_ingest.common.pandas_utils import split_df_rows_on_splits
 from kf_lib_data_ingest.common.stage import IngestStage
-from kf_lib_data_ingest.common.type_safety import function
+from kf_lib_data_ingest.common.type_safety import (
+    assert_all_safe_type,
+    assert_safe_type,
+    is_function
+)
 from kf_lib_data_ingest.etl.configuration.base_config import (
     ConfigValidationError
 )
 from kf_lib_data_ingest.etl.configuration.extract_config import ExtractConfig
-
-is_function = function  # simple alias for clarity
 
 
 def lcm(number_list):
@@ -40,13 +43,20 @@ def lcm(number_list):
 
 class ExtractStage(IngestStage):
     def __init__(
-        self, stage_cache_dir, extract_config_paths
+        self, stage_cache_dir, extract_config_paths, expected_counts=None
     ):
         super().__init__(stage_cache_dir)
         if isinstance(extract_config_paths, list):
             self.extract_configs = [ExtractConfig(config_filepath)
                                     for config_filepath
                                     in extract_config_paths]
+        elif isinstance(extract_config_paths, str):
+            self.extract_configs = [ExtractConfig(extract_config_paths)]
+
+        assert_safe_type(expected_counts, None, dict)
+        if isinstance(expected_counts, dict):
+            assert_all_safe_type(expected_counts.values(), int)
+        self.expected_counts = expected_counts
         self.FR = FileRetriever()
 
     def _output_path(self):
@@ -140,69 +150,6 @@ class ExtractStage(IngestStage):
                 in zip(op.__code__.co_freevars, op.__closure__)
             })
         self.logger.info(msg)
-
-    def _run(self):
-        """
-        :returns: A dictionary where a key is the URL to the extract_config
-            that produced the dataframe and a value is a tuple containing:
-            (<URL to source data file>, <extracted DataFrame>)
-        """
-        output = {}
-        for extract_config in self.extract_configs:
-            self.logger.info(
-                "Extract config: %s", extract_config.config_filepath
-            )
-            protocol, path = split_protocol(extract_config.source_data_url)
-            if protocol == 'file':
-                if path.startswith('.'):
-                    # relative paths from the extract config location
-                    path = os.path.normpath(
-                        os.path.join(
-                            os.path.dirname(extract_config.config_filepath),
-                            path
-                        )
-                    )
-                else:
-                    path = os.path.expanduser(path)
-
-            data_path = protocol + PROTOCOL_SEP + path
-
-            # read contents from file
-            try:
-                df_in = self._source_file_to_df(
-                    data_path,
-                    do_after_load=extract_config.do_after_load,
-                    load_func=extract_config.load_func,
-                    **(extract_config.loading_params)
-                )
-            except ConfigValidationError as e:
-                raise type(e)(
-                    f'In extract config {extract_config.config_filepath}'
-                    f' : {str(e)}'
-                )
-
-            self.logger.debug(
-                "Loaded DataFrame with dimensions %s", df_in.shape
-            )
-
-            # extraction
-            df_out = self._chain_operations(
-                df_in, extract_config.operations
-            )
-
-            # split value lists into separate rows
-            df_out = split_df_rows_on_splits(
-                df_out.reset_index()
-            ).set_index('index')
-            del df_out.index.name
-
-            # standardize values again after operations
-            df_out = self._clean_up_df(df_out)
-
-            output[extract_config.config_filepath] = (data_path, df_out)
-
-        # return dictionary of all dataframes keyed by extract config paths
-        return output
 
     def _clean_up_df(self, df):
         # We can't universally control which null type will get used by a data
@@ -376,3 +323,134 @@ class ExtractStage(IngestStage):
                     index = col_index
         df_out.index = index
         return df_out
+
+    def _run(self):
+        """
+        :returns: A dictionary where a key is the URL to the extract_config
+            that produced the dataframe and a value is a tuple containing:
+            (<URL to source data file>, <extracted DataFrame>)
+        """
+        output = {}
+        for extract_config in self.extract_configs:
+            self.logger.info(
+                "Extract config: %s", extract_config.config_filepath
+            )
+            protocol, path = split_protocol(extract_config.source_data_url)
+            if protocol == 'file':
+                if path.startswith('.'):
+                    # relative paths from the extract config location
+                    path = os.path.normpath(
+                        os.path.join(
+                            os.path.dirname(extract_config.config_filepath),
+                            path
+                        )
+                    )
+                else:
+                    path = os.path.expanduser(path)
+
+            data_path = protocol + PROTOCOL_SEP + path
+
+            # read contents from file
+            try:
+                df_in = self._source_file_to_df(
+                    data_path,
+                    do_after_load=extract_config.do_after_load,
+                    load_func=extract_config.load_func,
+                    **(extract_config.loading_params)
+                )
+            except ConfigValidationError as e:
+                raise type(e)(
+                    f'In extract config {extract_config.config_filepath}'
+                    f' : {str(e)}'
+                )
+
+            self.logger.debug(
+                "Loaded DataFrame with dimensions %s", df_in.shape
+            )
+
+            # extraction
+            df_out = self._chain_operations(
+                df_in, extract_config.operations
+            )
+
+            # split value lists into separate rows
+            df_out = split_df_rows_on_splits(
+                                                df_out.reset_index()
+                                            ).set_index('index')
+            del df_out.index.name
+
+            # standardize values again after operations
+            df_out = self._clean_up_df(df_out)
+
+            output[extract_config.config_filepath] = (data_path, df_out)
+
+        # return dictionary of all dataframes keyed by extract config paths
+        return output
+
+    def _postrun_accounting(self, run_output):
+        """
+        See the docstring for IngestStage._postrun_accounting.
+        """
+        # Storage for where all of the values for each concept key are found
+        # counted = {
+        #     a_key: {
+        #         a1: [file1, file2],
+        #         ...
+        #     },
+        #     ...
+        # }
+        counted = defaultdict(
+            lambda: defaultdict(set)
+        )
+
+        for config_path, (data_file, df) in run_output.items():
+            for key in df.columns:
+                for val in df[key]:
+                    counted[key][val].add(data_file)
+
+        uniques = {
+            key: len(unique_vals) for key, unique_vals in counted.items()
+        }
+
+        # display unique counts
+
+        message = ['UNIQUE COUNTS']
+        message.append(
+            pformat(uniques)
+        )
+        message.append('')
+
+        # check expected counts
+
+        all_checks_passed = True
+        message.append('EXPECTED COUNT CHECKS')
+
+        if not self.expected_counts:
+            message.append("No expected counts registered. ❌")
+            all_checks_passed = False
+        else:
+            checks = pandas.DataFrame(
+                columns=['key', 'expected', 'found', 'pass']
+            )
+            for key, expected in self.expected_counts.items():
+                found = uniques.get(key)
+                if expected == found:
+                    passed = '✅'
+                else:
+                    all_checks_passed = False
+                    passed = '❌'
+                checks = checks.append(
+                    {
+                        'key': key, 'expected': expected, 'found': found,
+                        'pass': passed
+                    },
+                    ignore_index=True
+                )
+            message.append(
+                tabulate(
+                    checks,
+                    headers='keys', showindex=False, tablefmt='psql'
+                )
+            )
+
+        return all_checks_passed, counted, '\n'.join(message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ boto3==1.9.51
 networkx==2.1
 xlrd==1.1.0
 requests==2.21.0
+tabulate==0.8.3

--- a/tests/data/test_study/dataset_ingest_config.yml
+++ b/tests/data/test_study/dataset_ingest_config.yml
@@ -26,7 +26,7 @@ extract_config_dir: 'extract_configs'
 transform_function_path: 'transform_module.py'
 
 expected_counts:
-  'CONCEPT|BIOSPECIMEN|ID': 60
+  'CONCEPT|BIOSPECIMEN': 60
   'CONCEPT|PARTICIPANT|ID': 25
 
 study:

--- a/tests/data/test_study/dataset_ingest_config.yml
+++ b/tests/data/test_study/dataset_ingest_config.yml
@@ -25,6 +25,10 @@ extract_config_dir: 'extract_configs'
 
 transform_function_path: 'transform_module.py'
 
+expected_counts:
+  'CONCEPT|BIOSPECIMEN|ID': 60
+  'CONCEPT|PARTICIPANT|ID': 25
+
 study:
     kf_id: 'SD_MEOWMEOW'
     external_id: 'phs0001999'

--- a/tests/test_extract_stage.py
+++ b/tests/test_extract_stage.py
@@ -73,7 +73,7 @@ def test_extracts():
     for study_dir, study_configs in expected_results.items():
         extract_configs = list(study_configs.keys())
         es = ExtractStage(os.path.join(study_dir, 'output'), extract_configs)
-        df_out = es.run()
+        df_out, _, _ = es.run()
         recycled_output = es.read_output()
 
         for config in extract_configs:

--- a/tests/test_ingest_stage.py
+++ b/tests/test_ingest_stage.py
@@ -104,7 +104,7 @@ def test_stage_read_write(ValidIngestStage):
     # Test output is written and read when stage_cache_dir is defined
     stage = ValidIngestStage(ingest_output_dir=TEST_INGEST_OUTPUT_DIR)
     run_input = 'hello world'
-    run_output = stage.run(run_input)
+    run_output, _, _ = stage.run(run_input)
     assert stage.read_output() == run_output
 
 

--- a/tests/test_transform_stage.py
+++ b/tests/test_transform_stage.py
@@ -53,7 +53,7 @@ def test_read_write(guided_transform_stage, df):
     extract_output = {'extract_config_url': ('source_url', df)}
 
     # Transform outputs json
-    output = guided_transform_stage.run(extract_output)
+    output, _, _ = guided_transform_stage.run(extract_output)
     recycled_output = guided_transform_stage.read_output()
 
     for target_entity, data in output.items():


### PR DESCRIPTION
<strike>Currently outputs something like...

```
POST-EXTRACT ACCOUNTING

Participants  -  'CONCEPT|PARTICIPANT|ID'
-----------------------------------------
Found: 24
Expected: 24 ✅

Specimens  -  'CONCEPT|BIOSPECIMEN|ID'
--------------------------------------
Found: 60
Expected: 'expected_num_specimens' not set in /path/to/study/dataset_ingest_config.yml

Genomic Files  -  'CONCEPT|GENOMIC_FILE|FILE_PATH'
--------------------------------------------------
Found: 180

Every CONCEPT|BIOSPECIMEN|ALIQUOT_ID should (definitely) have a CONCEPT|PARTICIPANT|ID...
✅

Every CONCEPT|BIOSPECIMEN|ID should (definitely) have a CONCEPT|PARTICIPANT|ID...
❌...but these don't:
{ what doesn't : where it is }
{4: {'study_data/simple_headered_tsv_2.tsv',
     'study_data/unsimple_xlsx_1.xlsx'},
 5: {'study_data/simple_headered_tsv_2.tsv',
     'study_data/unsimple_xlsx_1.xlsx'},
 6: {'study_data/simple_headered_tsv_2.tsv',
     'study_data/unsimple_xlsx_1.xlsx'},
 7: {'study_data/simple_headered_tsv_2.tsv',
     'study_data/unsimple_xlsx_1.xlsx'},
 8: {'study_data/simple_headered_tsv_2.tsv',
     'study_data/unsimple_xlsx_1.xlsx'},
 9: {'study_data/simple_headered_tsv_2.tsv',
     'study_data/unsimple_xlsx_1.xlsx'},
 10: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 11: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 12: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 13: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 14: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 15: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 16: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 17: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 18: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 19: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 20: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 21: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 22: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 23: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 24: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 25: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 26: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 27: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 28: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 29: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 30: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 31: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 32: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 33: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 34: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 35: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 36: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 37: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 38: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 39: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 40: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 41: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 42: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 43: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 44: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 45: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 46: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 47: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 48: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 49: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 50: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 51: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 52: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 53: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 54: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 55: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 56: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 57: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 58: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 59: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 60: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 61: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 62: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'},
 63: {'study_data/simple_headered_tsv_2.tsv',
      'study_data/unsimple_xlsx_1.xlsx'}}

Every CONCEPT|PARTICIPANT|ID should (probably) have a CONCEPT|BIOSPECIMEN|ID...
❌...but these don't:
{ what doesn't : where it is }
{1: {'study_data/simple_headered_tsv_1.tsv',
     'study_data/split_rows_tsv_1.tsv'},
 2: {'study_data/simple_headered_tsv_1.tsv',
     'study_data/split_rows_tsv_1.tsv'},
 3: {'study_data/simple_headered_tsv_1.tsv',
     'study_data/split_rows_tsv_1.tsv'},
 4: {'study_data/simple_headered_tsv_1.tsv',
     'study_data/split_rows_tsv_1.tsv'},
 5: {'study_data/simple_headered_tsv_1.tsv',
     'study_data/split_rows_tsv_1.tsv'},
 6: {'study_data/simple_headered_tsv_1.tsv',
     'study_data/split_rows_tsv_1.tsv'},
 7: {'study_data/simple_headered_tsv_1.tsv',
     'study_data/split_rows_tsv_1.tsv'},
 8: {'study_data/simple_headered_tsv_1.tsv',
     'study_data/split_rows_tsv_1.tsv'},
 9: {'study_data/simple_headered_tsv_1.tsv',
     'study_data/split_rows_tsv_1.tsv'},
 10: {'study_data/simple_headered_tsv_1.tsv'},
 11: {'study_data/simple_headered_tsv_1.tsv'},
 12: {'study_data/simple_headered_tsv_1.tsv'},
 13: {'study_data/simple_headered_tsv_1.tsv'},
 14: {'study_data/simple_headered_tsv_1.tsv'},
 15: {'study_data/simple_headered_tsv_1.tsv'},
 16: {'study_data/simple_headered_tsv_1.tsv'},
 17: {'study_data/simple_headered_tsv_1.tsv'},
 18: {'study_data/simple_headered_tsv_1.tsv'},
 19: {'study_data/simple_headered_tsv_1.tsv'},
 20: {'study_data/simple_headered_tsv_1.tsv'},
 21: {'study_data/simple_headered_tsv_1.tsv'},
 22: {'study_data/simple_headered_tsv_1.tsv'},
 23: {'study_data/simple_headered_tsv_1.tsv'},
 24: {'study_data/simple_headered_tsv_1.tsv'}}

Every CONCEPT|PARTICIPANT|ID should (probably) have a CONCEPT|BIOSPECIMEN|ALIQUOT_ID...
❌...but these don't:
{ what doesn't : where it is }
{10: {'study_data/simple_headered_tsv_1.tsv'},
 11: {'study_data/simple_headered_tsv_1.tsv'},
 12: {'study_data/simple_headered_tsv_1.tsv'},
 13: {'study_data/simple_headered_tsv_1.tsv'},
 14: {'study_data/simple_headered_tsv_1.tsv'},
 15: {'study_data/simple_headered_tsv_1.tsv'},
 16: {'study_data/simple_headered_tsv_1.tsv'},
 17: {'study_data/simple_headered_tsv_1.tsv'},
 18: {'study_data/simple_headered_tsv_1.tsv'},
 19: {'study_data/simple_headered_tsv_1.tsv'},
 20: {'study_data/simple_headered_tsv_1.tsv'},
 21: {'study_data/simple_headered_tsv_1.tsv'},
 22: {'study_data/simple_headered_tsv_1.tsv'},
 23: {'study_data/simple_headered_tsv_1.tsv'},
 24: {'study_data/simple_headered_tsv_1.tsv'}}


```
</strike>