### PR TITLE
🚨 Pandas's SettingWithCopyWarning is so annoying

### DIFF
--- a/kf_lib_data_ingest/common/pandas_utils.py
+++ b/kf_lib_data_ingest/common/pandas_utils.py
@@ -280,11 +280,12 @@ def outer_merge(df1, df2, with_merge_detail_dfs=True, **kwargs):
         detail_dfs = [outer[outer['_merge'] == keyword]
                       for keyword in ['both', 'left_only', 'right_only']]
 
+        ret = []
         for df in [outer] + detail_dfs:
-            df.dropna(how="all", inplace=True)
             del df['_merge']
+            ret.append(df.dropna(how="all"))
 
-        return outer, detail_dfs[0], detail_dfs[1], detail_dfs[2]
+        return tuple(ret)
 
     else:
         return outer


### PR DESCRIPTION
remove the inplace assignment in dropna to squelch the dumb warning

```
tests/test_pandas_utils.py::test_outer_merge
 kf_lib_data_ingest/common/pandas_utils.py:286: SettingWithCopyWarning:
  A value is trying to be set on a copy of a slice from a DataFrame

  See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
    df.dropna(how="all", inplace=True)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```