### PR TITLE
✨ Small Logging Improvements

### DIFF
--- a/kf_lib_data_ingest/cli.py
+++ b/kf_lib_data_ingest/cli.py
@@ -6,7 +6,11 @@ import inspect
 
 import click
 
-from kf_lib_data_ingest.config import DEFAULT_TARGET_URL
+from kf_lib_data_ingest.config import (
+    DEFAULT_TARGET_URL,
+    DEFAULT_LOG_LEVEL
+)
+from kf_lib_data_ingest.etl.configuration.log import LOG_LEVELS
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
@@ -23,6 +27,9 @@ def cli():
 
 
 @click.command()
+@click.option('--log_level', type=click.Choice(LOG_LEVELS.keys()),
+              default=DEFAULT_LOG_LEVEL, show_default=True,
+              help='The level of log messages')
 @click.option('--use_async',
               default=False,
               is_flag=True,
@@ -39,7 +46,7 @@ def cli():
               help='Target service URL where data will be loaded into')
 @click.argument('dataset_ingest_config_path',
                 type=click.Path(exists=True, file_okay=True, dir_okay=True))
-def ingest(dataset_ingest_config_path, target_url, use_async):
+def ingest(dataset_ingest_config_path, target_url, use_async, log_level):
     """
     Run the Kids First data ingest pipeline.
 

--- a/kf_lib_data_ingest/cli.py
+++ b/kf_lib_data_ingest/cli.py
@@ -3,6 +3,7 @@ Entry point for the Kids First Data Ingest Client
 """
 import os
 import inspect
+import logging
 
 import click
 
@@ -10,9 +11,9 @@ from kf_lib_data_ingest.config import (
     DEFAULT_TARGET_URL,
     DEFAULT_LOG_LEVEL
 )
-from kf_lib_data_ingest.etl.configuration.log import LOG_LEVELS
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+DEFAULT_LOG_LEVEL_NAME = logging._levelToName.get(DEFAULT_LOG_LEVEL)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -27,9 +28,12 @@ def cli():
 
 
 @click.command()
-@click.option('--log_level', type=click.Choice(LOG_LEVELS.keys()),
-              default=DEFAULT_LOG_LEVEL, show_default=True,
-              help='The level of log messages')
+@click.option('--log_level', 'log_level_name', type=click.Choice(
+    map(str.lower, logging._nameToLevel.keys())),
+    help=('Controls level of log messages to output. If not supplied via CLI, '
+          'log_level from the dataset_ingest_config.yaml will be used. If not '
+          'supplied via config yaml, the default log_level for the ingest lib '
+          f'will be used: {DEFAULT_LOG_LEVEL_NAME}'))
 @click.option('--use_async',
               default=False,
               is_flag=True,
@@ -46,7 +50,7 @@ def cli():
               help='Target service URL where data will be loaded into')
 @click.argument('dataset_ingest_config_path',
                 type=click.Path(exists=True, file_okay=True, dir_okay=True))
-def ingest(dataset_ingest_config_path, target_url, use_async, log_level):
+def ingest(dataset_ingest_config_path, target_url, use_async, log_level_name):
     """
     Run the Kids First data ingest pipeline.
 

--- a/kf_lib_data_ingest/config.py
+++ b/kf_lib_data_ingest/config.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 ROOT_DIR = os.path.dirname(__file__)
 
@@ -13,7 +14,7 @@ TARGET_SERVICE_CONFIG_PATH = os.path.join(ROOT_DIR,
                                           'target_apis',
                                           'kids_first.py')
 DEFAULT_LOG_FILENAME = 'ingest.log'
-DEFAULT_LOG_LEVEL = 'info'
+DEFAULT_LOG_LEVEL = logging.INFO
 DEFAULT_LOG_OVERWRITE_OPT = True
 
 INGEST_PKG_TEMPLATE_NAME = 'my_study'

--- a/kf_lib_data_ingest/config.py
+++ b/kf_lib_data_ingest/config.py
@@ -1,5 +1,3 @@
-import logging
-import logging.handlers
 import os
 
 ROOT_DIR = os.path.dirname(__file__)
@@ -15,7 +13,7 @@ TARGET_SERVICE_CONFIG_PATH = os.path.join(ROOT_DIR,
                                           'target_apis',
                                           'kids_first.py')
 DEFAULT_LOG_FILENAME = 'ingest.log'
-DEFAULT_LOG_LEVEL = logging.INFO
+DEFAULT_LOG_LEVEL = 'info'
 DEFAULT_LOG_OVERWRITE_OPT = True
 
 INGEST_PKG_TEMPLATE_NAME = 'my_study'

--- a/kf_lib_data_ingest/etl/configuration/dataset_ingest_config.py
+++ b/kf_lib_data_ingest/etl/configuration/dataset_ingest_config.py
@@ -1,5 +1,4 @@
 import os
-import logging
 
 from kf_lib_data_ingest.etl.configuration.base_config import YamlConfig
 from kf_lib_data_ingest.config import (
@@ -71,9 +70,6 @@ class DatasetIngestConfig(YamlConfig):
                 os.mkdir(log_dir)
             return log_dir
 
-        def _get_log_level(log_level_str):
-            return getattr(logging, log_level_str.upper())
-
         # Log params with defaults
         log_params = {
             'log_dir': _default_log_dir,
@@ -87,8 +83,6 @@ class DatasetIngestConfig(YamlConfig):
             if ('logging' in self.contents and
                     (param in self.contents['logging'])):
                 value = self.contents['logging'][param]
-                if param == 'log_level':
-                    value = _get_log_level(value)
                 setattr(self, param, value)
             # Set default
             else:

--- a/kf_lib_data_ingest/etl/configuration/dataset_ingest_config.py
+++ b/kf_lib_data_ingest/etl/configuration/dataset_ingest_config.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 from kf_lib_data_ingest.etl.configuration.base_config import YamlConfig
 from kf_lib_data_ingest.config import (
@@ -83,6 +84,9 @@ class DatasetIngestConfig(YamlConfig):
             if ('logging' in self.contents and
                     (param in self.contents['logging'])):
                 value = self.contents['logging'][param]
+                if param == 'log_level':
+                    value = logging._nameToLevel.get(value.upper(),
+                                                     DEFAULT_LOG_LEVEL)
                 setattr(self, param, value)
             # Set default
             else:

--- a/kf_lib_data_ingest/etl/configuration/log.py
+++ b/kf_lib_data_ingest/etl/configuration/log.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import logging.handlers
 import os
 import time
 
@@ -8,6 +9,26 @@ from kf_lib_data_ingest.config import (
     DEFAULT_LOG_LEVEL,
     DEFAULT_LOG_FILENAME
 )
+
+
+def _log_level_dict():
+    """
+    Create log levels dict, where a key is the string representation of
+    log level and a value is the int representation of the level.
+
+    Log levels dict is used in cli.py to provide the enumeration of acceptable
+    choices for --log_level param.
+    """
+    # Log levels dict from logging
+    log_levels = logging._levelToName
+    # Remove the `noset` level, we don't need that
+    log_levels.pop(0)
+
+    return {v.lower(): k for k, v in log_levels.items()}
+
+
+LOG_LEVELS = _log_level_dict()
+DEFAULT_LOG_LEVEL_INT = LOG_LEVELS[DEFAULT_LOG_LEVEL]
 
 
 def create_default_logger(logger_name, log_level=logging.DEBUG):
@@ -65,7 +86,8 @@ def setup_logger(log_dir, overwrite_log=DEFAULT_LOG_OVERWRITE_OPT,
 
     # Set log level and handlers
     root = logging.getLogger()
-    root.setLevel(log_level)
+    root.setLevel(LOG_LEVELS.get(str(log_level).lower(),
+                                 DEFAULT_LOG_LEVEL_INT))
     root.addHandler(fileHandler)
     root.addHandler(consoleHandler)
 

--- a/kf_lib_data_ingest/etl/configuration/log.py
+++ b/kf_lib_data_ingest/etl/configuration/log.py
@@ -11,26 +11,6 @@ from kf_lib_data_ingest.config import (
 )
 
 
-def _log_level_dict():
-    """
-    Create log levels dict, where a key is the string representation of
-    log level and a value is the int representation of the level.
-
-    Log levels dict is used in cli.py to provide the enumeration of acceptable
-    choices for --log_level param.
-    """
-    # Log levels dict from logging
-    log_levels = logging._levelToName
-    # Remove the `noset` level, we don't need that
-    log_levels.pop(0)
-
-    return {v.lower(): k for k, v in log_levels.items()}
-
-
-LOG_LEVELS = _log_level_dict()
-DEFAULT_LOG_LEVEL_INT = LOG_LEVELS[DEFAULT_LOG_LEVEL]
-
-
 def create_default_logger(logger_name, log_level=logging.DEBUG):
     """
     Create a default logger that outputs to console
@@ -86,8 +66,7 @@ def setup_logger(log_dir, overwrite_log=DEFAULT_LOG_OVERWRITE_OPT,
 
     # Set log level and handlers
     root = logging.getLogger()
-    root.setLevel(LOG_LEVELS.get(str(log_level).lower(),
-                                 DEFAULT_LOG_LEVEL_INT))
+    root.setLevel(log_level)
     root.addHandler(fileHandler)
     root.addHandler(consoleHandler)
 

--- a/kf_lib_data_ingest/etl/ingest_pipeline.py
+++ b/kf_lib_data_ingest/etl/ingest_pipeline.py
@@ -42,7 +42,16 @@ class DataIngestPipeline(object):
         Entry point for data ingestion. Run ingestion in the top level
         exception handler so that exceptions are logged.
 
-        See _run method for param description
+        :param target_api_config_path: Path to the target api config file
+        :param auto_transform: Boolean specifies whether to use automatic
+        graph-based transformation or user guided transformation
+        :param use_async: Boolean specifies whether to do ingest
+        asynchronously or synchronously
+        :param target_url: URL of the target API, into which data will be
+        loaded. Use default if none is supplied
+        :param log_level_name: case insensitive name of log level
+        (i.e. info, debug, etc) to control logging output.
+        See keys in logging._nameToLevel dict for all possible options
         """
         # Get args, kwargs
         frame = inspect.currentframe()
@@ -55,7 +64,6 @@ class DataIngestPipeline(object):
                       for param in ['overwrite_log', 'log_level']}
 
         # Apply any log parameter overrides
-
         log_level_name = kwargs.pop('log_level_name')
         log_level = logging._nameToLevel.get(str(log_level_name).upper())
         if log_level:
@@ -86,11 +94,7 @@ class DataIngestPipeline(object):
         """
         Runs the ingest pipeline
 
-        :param target_api_config_path: Path to the target api config file
-        :param use_async: Boolean specifies whether to do ingest
-        asynchronously or synchronously
-        :param target_url: URL of the target API, into which data will be
-        loaded. Use default if none is supplied
+        See run method for description of keyword args
         """
         # Create an ordered dict of all ingest stages and their parameters
         self.stage_dict = OrderedDict()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import time
 
 import pytest
@@ -14,7 +15,6 @@ from conftest import (
     TEST_DATA_DIR,
     KIDS_FIRST_CONFIG
 )
-from kf_lib_data_ingest.etl.configuration.log import LOG_LEVELS
 from kf_lib_data_ingest.etl.ingest_pipeline import DataIngestPipeline
 from kf_lib_data_ingest import cli
 
@@ -115,7 +115,7 @@ def test_cli_log_overrides(caplog):
     """
     # Pytest caplog fixture is set to WARNING by default. Set to DEBUG so
     # we can capture log messages
-    caplog.set_level(LOG_LEVELS.get('debug'))
+    caplog.set_level(logging._nameToLevel.get('DEBUG'))
 
     # Run with no override, log level should be info
     runner = CliRunner()
@@ -162,5 +162,5 @@ def _check_log_levels(log_text, levels):
     Check that no log msg in `log_text` has any of the log levels in `levels`
     """
     for line in log_text.split('\n'):
-        level = line.split('-')[-1].lower()
-        assert level not in {'debug', 'notset'}
+        level = line.split('-')[-1]
+        assert level.lower() not in levels

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,6 +2,7 @@ import os
 import time
 
 import pytest
+from click.testing import CliRunner
 
 from kf_lib_data_ingest.config import (
     DEFAULT_LOG_FILENAME,
@@ -13,7 +14,9 @@ from conftest import (
     TEST_DATA_DIR,
     KIDS_FIRST_CONFIG
 )
+from kf_lib_data_ingest.etl.configuration.log import LOG_LEVELS
 from kf_lib_data_ingest.etl.ingest_pipeline import DataIngestPipeline
+from kf_lib_data_ingest import cli
 
 target_api_config_path = KIDS_FIRST_CONFIG
 default_log_dir = os.path.join(TEST_DATA_DIR, 'test_study', 'logs')


### PR DESCRIPTION
Addresses part of #158 

- We were doing weird things with the log_level before. Now we use str log levels in inputs (CLI opts, dataset_ingest_config, etc) and then later on we convert to int version of the log level during setup of the logger
- Add log_level CLI option which overrides the log_level set in `dataset_ingest_config.yml`