### PR TITLE
🐛 boyd test config has an inverted check on hidden families

### DIFF
--- a/tests/data/test_boyd_study/extract_configs/Boyd_Minimal_Data_Elements_Cuellar_9-2-2018_EDITED_v2_map.py
+++ b/tests/data/test_boyd_study/extract_configs/Boyd_Minimal_Data_Elements_Cuellar_9-2-2018_EDITED_v2_map.py
@@ -54,7 +54,7 @@ operations = [
         out_col=CONCEPT.FAMILY.ID
     ),
     value_map(
-        m=lambda x: x not in {'1333', '2044'},  # these families are mangled
+        m=lambda x: x in {'1333', '2044'},  # these families are mangled
         in_col='Family Group ID',
         out_col=CONCEPT.FAMILY.HIDDEN
     ),


### PR DESCRIPTION
fixes #167