### PR TITLE
🐛 The dataservice throws 500 if gen3 does

### DIFF
--- a/kf_lib_data_ingest/common/misc.py
+++ b/kf_lib_data_ingest/common/misc.py
@@ -154,7 +154,7 @@ def upper_camel_case(snake_str):
 
 def requests_retry_session(
         session=None, total=3, read=3, connect=0, status=3,
-        backoff_factor=5, status_forcelist=(502, 503, 504)
+        backoff_factor=5, status_forcelist=(500, 502, 503, 504)
 ):
     """
     Send an http request and retry on failures or redirects


### PR DESCRIPTION
Gen3 throws internal errors if you ask it to walk and chew gum at the same time. 
Then the dataservice forwards the 500 status, which basically kills GF endpoint access until https://github.com/kids-first/kf-api-dataservice/issues/487 gets fixed.