### PR TITLE
♻️ reshape the stage queue

### DIFF
--- a/kf_lib_data_ingest/cli.py
+++ b/kf_lib_data_ingest/cli.py
@@ -94,20 +94,5 @@ def create_new_ingest(dest_dir=None):
     new_ingest_pkg(dest_dir)
 
 
-@click.command()
-def extract():
-    pass
-
-
-@click.command()
-def transform():
-    pass
-
-
-@click.command()
-def load():
-    pass
-
-
 cli.add_command(ingest)
 cli.add_command(create_new_ingest)

--- a/kf_lib_data_ingest/cli.py
+++ b/kf_lib_data_ingest/cli.py
@@ -73,11 +73,10 @@ def ingest(dataset_ingest_config_path, target_url, use_async, log_level_name):
     target_api_config_path = os.path.join(
         root_dir, 'target_apis', 'kids_first.py')
 
-    # Construct ingest pipeline
-    p = DataIngestPipeline(dataset_ingest_config_path)
-
     # Run ingest
-    p.run(target_api_config_path, **kwargs)
+    DataIngestPipeline(
+        dataset_ingest_config_path, target_api_config_path, **kwargs
+    ).run()
 
 
 @click.command(name='new')

--- a/kf_lib_data_ingest/etl/ingest_pipeline.py
+++ b/kf_lib_data_ingest/etl/ingest_pipeline.py
@@ -97,7 +97,7 @@ class DataIngestPipeline(object):
         args, _, _, values = inspect.getargvalues(frame)
         kwargs = {arg: values[arg] for arg in args[2:]}
         self.logger.info(
-            '-- Ingest Params --\n\t{}'.format(pformat(kwargs))
+            f'-- Ingest Params --\n{pformat(kwargs)}'
         )
 
     def _iterate_stages(self):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,18 +1,10 @@
 import logging
 import os
-import time
 
 import pytest
 from click.testing import CliRunner
 
-from conftest import (
-    KIDS_FIRST_CONFIG,
-    TEST_DATA_DIR,
-    TEST_LOG_DIR,
-    TEST_ROOT_DIR,
-    make_ingest_pipeline,
-    delete_dir
-)
+from conftest import TEST_LOG_DIR, make_ingest_pipeline
 from kf_lib_data_ingest import cli
 from kf_lib_data_ingest.config import (
     DEFAULT_LOG_FILENAME,
@@ -40,25 +32,18 @@ def test_defaults(ingest_pipeline):
     assert os.path.isfile(log_filepath) is True
 
 
-def test_log_dir():
+def test_log_dir(tmpdir):
     """
     Test non-default log dir
     """
-    # Custom log dir
-    log_dir = os.path.join(TEST_ROOT_DIR, 'mylogs')
-    delete_dir(log_dir)
-    os.mkdir(log_dir)
-
-    ingest_pipeline = make_ingest_pipeline(log_dir=log_dir)
+    log_dir = tmpdir.mkdir('my_logs')
+    ingest_pipeline = make_ingest_pipeline(log_dir=log_dir.strpath)
 
     # Run and generate logs
     ingest_pipeline.run()
 
     # User supplied log dir should exist
     assert len(os.listdir(log_dir)) == 1
-
-    # Delete the entire log directory
-    delete_dir(log_dir)
 
 
 def test_overwrite_log(ingest_pipeline):
@@ -134,7 +119,10 @@ def test_log_exceptions(ingest_pipeline):
             raise Exception('An exception occurred during ingestion!')
 
     # Create pipeline instance
-    p = NewPipeline(ingest_pipeline.data_ingest_config.config_filepath)
+    p = NewPipeline(
+        ingest_pipeline.data_ingest_config.config_filepath,
+        ingest_pipeline.target_api_config_path
+    )
     p.data_ingest_config.contents['logging'] = {
         'overwrite_log': True
     }

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,25 +1,25 @@
-import os
 import logging
+import os
 import time
 
 import pytest
 from click.testing import CliRunner
 
+from conftest import (
+    KIDS_FIRST_CONFIG,
+    TEST_DATA_DIR,
+    TEST_LOG_DIR,
+    TEST_ROOT_DIR,
+    make_ingest_pipeline,
+    delete_dir
+)
+from kf_lib_data_ingest import cli
 from kf_lib_data_ingest.config import (
     DEFAULT_LOG_FILENAME,
     DEFAULT_LOG_LEVEL,
     DEFAULT_LOG_OVERWRITE_OPT
 )
-from conftest import (
-    TEST_ROOT_DIR,
-    TEST_DATA_DIR,
-    KIDS_FIRST_CONFIG
-)
 from kf_lib_data_ingest.etl.ingest_pipeline import DataIngestPipeline
-from kf_lib_data_ingest import cli
-
-target_api_config_path = KIDS_FIRST_CONFIG
-default_log_dir = os.path.join(TEST_DATA_DIR, 'test_study', 'logs')
 
 
 def test_defaults(ingest_pipeline):
@@ -29,33 +29,36 @@ def test_defaults(ingest_pipeline):
 
     # Test that default log params were set on config
     log_dir = ingest_pipeline.data_ingest_config.log_dir
-    assert log_dir == default_log_dir
+    assert log_dir == TEST_LOG_DIR
     assert ingest_pipeline.data_ingest_config.log_level == DEFAULT_LOG_LEVEL
     assert (ingest_pipeline.data_ingest_config.overwrite_log ==
             DEFAULT_LOG_OVERWRITE_OPT)
 
     # Test that ingest.log was created
-    ingest_pipeline.run(target_api_config_path)
-    log_filepath = os.path.join(default_log_dir, DEFAULT_LOG_FILENAME)
+    ingest_pipeline.run()
+    log_filepath = os.path.join(TEST_LOG_DIR, DEFAULT_LOG_FILENAME)
     assert os.path.isfile(log_filepath) is True
 
 
-def test_log_dir(ingest_pipeline):
+def test_log_dir():
     """
     Test non-default log dir
     """
-    # Create log dir
+    # Custom log dir
     log_dir = os.path.join(TEST_ROOT_DIR, 'mylogs')
+    delete_dir(log_dir)
     os.mkdir(log_dir)
-    # Update data ingest config
-    ingest_pipeline.data_ingest_config.contents['logging'] = {
-        'log_dir': log_dir}
-    ingest_pipeline.data_ingest_config._set_log_params()
+
+    ingest_pipeline = make_ingest_pipeline(log_dir=log_dir)
+
     # Run and generate logs
-    ingest_pipeline.run(target_api_config_path)
+    ingest_pipeline.run()
 
     # User supplied log dir should exist
     assert len(os.listdir(log_dir)) == 1
+
+    # Delete the entire log directory
+    delete_dir(log_dir)
 
 
 def test_overwrite_log(ingest_pipeline):
@@ -63,29 +66,20 @@ def test_overwrite_log(ingest_pipeline):
     Test that overwriting the default log file works
     """
     log_dir = ingest_pipeline.data_ingest_config.log_dir
-    assert len(os.listdir(log_dir)) == 0
-
-    # Run and generate logs
-    ingest_pipeline.run(target_api_config_path)
 
     # Check for default log file
     assert len(os.listdir(log_dir)) == 1
-    log_filepath = os.path.join(log_dir, DEFAULT_LOG_FILENAME)
-    assert os.path.isfile(log_filepath) is True
+    assert os.path.isfile(ingest_pipeline.log_file_path) is True
 
     # No new files should be created
-    ingest_pipeline.run(target_api_config_path)
+    ingest_pipeline.run()
     assert len(os.listdir(log_dir)) == 1
 
-    # Update data ingest config
-    ingest_pipeline.data_ingest_config.contents['logging'] = {
-        'overwrite_log': False}
-    ingest_pipeline.data_ingest_config._set_log_params()
-
-    # Test that new logs are created on each run
-    time.sleep(1)
-    ingest_pipeline.run(target_api_config_path)
-    assert len(os.listdir(default_log_dir)) == 2
+    # Test that new logs are created on each pipeline with overwrite_false
+    make_ingest_pipeline(overwrite_log=False)
+    assert len(os.listdir(log_dir)) == 2
+    make_ingest_pipeline(overwrite_log=False)
+    assert len(os.listdir(log_dir)) == 3
 
 
 def test_log_level(ingest_pipeline):
@@ -100,7 +94,7 @@ def test_log_level(ingest_pipeline):
     ingest_pipeline.data_ingest_config._set_log_params()
 
     # Run and generate log
-    ingest_pipeline.run(target_api_config_path)
+    ingest_pipeline.run()
 
     # Check log content
     log_filepath = os.path.join(ingest_pipeline.data_ingest_config.log_dir,
@@ -148,7 +142,7 @@ def test_log_exceptions(ingest_pipeline):
 
     # Exception is thrown and log should include exception
     with pytest.raises(Exception):
-        p.run(target_api_config_path)
+        p.run()
         log_filepath = os.path.join(p.data_ingest_config.log_dir,
                                     DEFAULT_LOG_FILENAME)
 


### PR DESCRIPTION
The pipeline wasn't really made to be reusable, but it's sometimes
treated like it is, and that seems dangerous. This migrates pieces of the
pipeline so that configuration arguments all go to init, the logger
gets set up right away, and the stages get constructed directly instead
of being put into (and then pulled back out of) bags of parameters.

It resists treating DataIngestPipeline instances as things to modify and
run again and gets us closer to having a "do my stuff" executive
invocation.

This is part one of converting the DataIngestPipeline class into a
straightforward ingest_data function since you basically just call
run right away _anyway_.

This also adds some kwargs which override the defaults set in the dataset_ingest_config.yaml, but that's mostly just to work in the current testing methodology.