### PR TITLE
♻️ Separate stage tally format from checks

### DIFF
--- a/kf_lib_data_ingest/cli.py
+++ b/kf_lib_data_ingest/cli.py
@@ -1,16 +1,14 @@
 """
 Entry point for the Kids First Data Ingest Client
 """
-import os
 import inspect
 import logging
+import os
+import sys
 
 import click
 
-from kf_lib_data_ingest.config import (
-    DEFAULT_TARGET_URL,
-    DEFAULT_LOG_LEVEL
-)
+from kf_lib_data_ingest.config import DEFAULT_LOG_LEVEL, DEFAULT_TARGET_URL
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 DEFAULT_LOG_LEVEL_NAME = logging._levelToName.get(DEFAULT_LOG_LEVEL)
@@ -74,9 +72,12 @@ def ingest(dataset_ingest_config_path, target_url, use_async, log_level_name):
         root_dir, 'target_apis', 'kids_first.py')
 
     # Run ingest
-    DataIngestPipeline(
+    err = DataIngestPipeline(
         dataset_ingest_config_path, target_api_config_path, **kwargs
     ).run()
+
+    if err:
+        sys.exit(1)
 
 
 @click.command(name='new')

--- a/kf_lib_data_ingest/cli.py
+++ b/kf_lib_data_ingest/cli.py
@@ -72,11 +72,11 @@ def ingest(dataset_ingest_config_path, target_url, use_async, log_level_name):
         root_dir, 'target_apis', 'kids_first.py')
 
     # Run ingest
-    err = DataIngestPipeline(
+    perfection = DataIngestPipeline(
         dataset_ingest_config_path, target_api_config_path, **kwargs
     ).run()
 
-    if err:
+    if not perfection:
         sys.exit(1)
 
 

--- a/kf_lib_data_ingest/common/misc.py
+++ b/kf_lib_data_ingest/common/misc.py
@@ -11,6 +11,7 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from requests.exceptions import ConnectionError
 import yaml
+import jsonpickle
 
 from kf_lib_data_ingest.common.type_safety import assert_safe_type
 
@@ -42,15 +43,18 @@ def read_json(filepath, default=None):
     """
     if (default is not None) and (not os.path.isfile(filepath)):
         return default
-
     with open(filepath, 'r') as json_file:
-        return json.load(json_file)
+        json_str = json_file.read()
+    return jsonpickle.decode(json_str)
 
 
 def write_json(data, filepath):
+    json_str = json.loads(jsonpickle.encode(data))
     with open(filepath, 'w') as json_file:
-        json.dump(data, json_file, sort_keys=True, indent=4,
-                  separators=(',', ':'))
+        json.dump(
+            json_str,
+            json_file, sort_keys=True, indent=4, separators=(',', ':')
+        )
 
 
 def iterate_pairwise(iterable):

--- a/kf_lib_data_ingest/common/misc.py
+++ b/kf_lib_data_ingest/common/misc.py
@@ -39,8 +39,13 @@ def read_json(filepath, default=None, use_jsonpickle=True):
     does not exist, then return default.
 
     :param filepath: path to JSON file
-    :param default: default return value if file is not found
-    :param use_jsonpickle: whether to allow pickling of JSON-incompatible types
+    :type filepath: str
+    :param default: default return value if file not found, defaults to None
+    :type default: any, optional
+    :param use_jsonpickle: pickle JSON-incompatible types, defaults to True
+    :type use_jsonpickle: bool, optional
+    :return: your data
+    :rtype: dict
     """
     if (default is not None) and (not os.path.isfile(filepath)):
         return default
@@ -53,21 +58,26 @@ def read_json(filepath, default=None, use_jsonpickle=True):
             return json.load(json_file)
 
 
-def write_json(data, filepath, use_jsonpickle=True):
-    """
+def write_json(data, filepath, use_jsonpickle=True, **kwargs):
+    r"""
     Write Python dict to JSON file.
 
-    :param data: your python dict
-    :param filepath: path for new JSON file
-    :param use_jsonpickle: whether to allow pickling of JSON-incompatible types
+    :param data: your data
+    :type data: dict
+    :param filepath: where to write your JSON file
+    :type filepath: str
+    :param use_jsonpickle: pickle JSON-incompatible types, defaults to True
+    :type use_jsonpickle: bool, optional
+    :param \**kwargs: keyword arguments to pass to json.dump
     """
+    if 'indent' not in kwargs:
+        kwargs['indent'] = 4
+    if 'sort_keys' not in kwargs:
+        kwargs['sort_keys'] = True
     with open(filepath, 'w') as json_file:
         if use_jsonpickle:
             data = json.loads(jsonpickle.encode(data))
-        json.dump(
-            data,
-            json_file, sort_keys=True, indent=4, separators=(',', ':')
-        )
+        json.dump(data, json_file, **kwargs)
 
 
 def iterate_pairwise(iterable):

--- a/kf_lib_data_ingest/common/misc.py
+++ b/kf_lib_data_ingest/common/misc.py
@@ -33,26 +33,39 @@ def read_yaml(filepath):
         return yaml.load(yaml_file, Loader=yaml.FullLoader)
 
 
-def read_json(filepath, default=None):
+def read_json(filepath, default=None, use_jsonpickle=True):
     """
     Read JSON file into Python dict. If default is not None and the file
-    does not exist, then return default
+    does not exist, then return default.
 
     :param filepath: path to JSON file
     :param default: default return value if file is not found
+    :param use_jsonpickle: whether to allow pickling of JSON-incompatible types
     """
     if (default is not None) and (not os.path.isfile(filepath)):
         return default
+
     with open(filepath, 'r') as json_file:
-        json_str = json_file.read()
-    return jsonpickle.decode(json_str)
+        if use_jsonpickle:
+            json_str = json_file.read()
+            return jsonpickle.decode(json_str)
+        else:
+            return json.load(json_file)
 
 
-def write_json(data, filepath):
-    json_str = json.loads(jsonpickle.encode(data))
+def write_json(data, filepath, use_jsonpickle=True):
+    """
+    Write Python dict to JSON file.
+
+    :param data: your python dict
+    :param filepath: path for new JSON file
+    :param use_jsonpickle: whether to allow pickling of JSON-incompatible types
+    """
     with open(filepath, 'w') as json_file:
+        if use_jsonpickle:
+            data = json.loads(jsonpickle.encode(data))
         json.dump(
-            json_str,
+            data,
             json_file, sort_keys=True, indent=4, separators=(',', ':')
         )
 

--- a/kf_lib_data_ingest/common/stage.py
+++ b/kf_lib_data_ingest/common/stage.py
@@ -47,7 +47,7 @@ class IngestStage(ABC):
     def _run(self, *args, **kwargs):
         pass
 
-    def _postrun_discovery(self, run_output):
+    def _postrun_concept_discovery(self, run_output):
         """
         Builds a dict which stores:
             - All unique standard concept attributes (e.g. each PARTICIPANT.ID)
@@ -152,6 +152,6 @@ class IngestStage(ABC):
         # Write output of stage to disk
         self.write_output(output)
 
-        output_tally = self._postrun_discovery(output)
+        output_tally = self._postrun_concept_discovery(output)
 
         return output, output_tally

--- a/kf_lib_data_ingest/common/stage.py
+++ b/kf_lib_data_ingest/common/stage.py
@@ -47,6 +47,7 @@ class IngestStage(ABC):
     def _run(self, *args, **kwargs):
         pass
 
+    @abstractmethod
     def _postrun_concept_discovery(self, run_output):
         """
         Builds a dict which stores:

--- a/kf_lib_data_ingest/common/stage.py
+++ b/kf_lib_data_ingest/common/stage.py
@@ -152,6 +152,6 @@ class IngestStage(ABC):
         # Write output of stage to disk
         self.write_output(output)
 
-        output_tally = self._postrun_concept_discovery(output)
+        concept_discovery_dict = self._postrun_concept_discovery(output)
 
-        return output, output_tally
+        return output, concept_discovery_dict

--- a/kf_lib_data_ingest/common/stage.py
+++ b/kf_lib_data_ingest/common/stage.py
@@ -47,16 +47,17 @@ class IngestStage(ABC):
     def _run(self, *args, **kwargs):
         pass
 
-    def _postrun_tally(self, run_output):
+    def _postrun_discovery(self, run_output):
         """
-        Tallies counts in run output.
+        Builds a dict which stores:
+            - All unique standard concept attributes (e.g. each PARTICIPANT.ID)
+            found in the stage output mapped to lists of the places they appear
+            - All unique pairs of standard concept attributes found in the
+            stage output (e.g. which BIOSPECIMEN.IDs are connected to which
+            PARTICIPANT.IDs etc)
 
-        :param run_output: the output returned by the _run() method
-        :return: A dict where 1) concept values map to a list of the sources
-        containing them and 2) concept values map to lists of linked concept
-        values
-
-        tally = {
+        dict template
+        {
             'sources': {
                 a_key: {  # e.g. PARTICIPANT.ID
                     a1: [f1, f2],  # e.g. PARTICIPANT.ID==a1 in files f1 & f2
@@ -71,6 +72,11 @@ class IngestStage(ABC):
                 }
             }
         }
+
+        :param run_output: the output returned by the _run() method
+        :return: A dict where 1) concept values map to a list of the sources
+        containing them and 2) concept values map to lists of linked concept
+        values
         """
         return {'sources': None, 'links': None}
 
@@ -146,6 +152,6 @@ class IngestStage(ABC):
         # Write output of stage to disk
         self.write_output(output)
 
-        output_tally = self._postrun_tally(output)
+        output_tally = self._postrun_discovery(output)
 
         return output, output_tally

--- a/kf_lib_data_ingest/etl/extract/extract.py
+++ b/kf_lib_data_ingest/etl/extract/extract.py
@@ -401,7 +401,7 @@ class ExtractStage(IngestStage):
                 for keyB in df.columns:
                     if keyB != keyA:
                         for i in range(len(df)):
-                            links[keyA + keyB][df[keyA].iloc[i]].add(
+                            links[keyA + '::' + keyB][df[keyA].iloc[i]].add(
                                 df[keyB].iloc[i]
                             )
 

--- a/kf_lib_data_ingest/etl/extract/extract.py
+++ b/kf_lib_data_ingest/etl/extract/extract.py
@@ -382,9 +382,9 @@ class ExtractStage(IngestStage):
         # return dictionary of all dataframes keyed by extract config paths
         return output
 
-    def _postrun_discovery(self, run_output):
+    def _postrun_concept_discovery(self, run_output):
         """
-        See the docstring for IngestStage._postrun_discovery.
+        See the docstring for IngestStage._postrun_concept_discovery
         """
         sources = defaultdict(
             lambda: defaultdict(set)

--- a/kf_lib_data_ingest/etl/extract/extract.py
+++ b/kf_lib_data_ingest/etl/extract/extract.py
@@ -382,9 +382,9 @@ class ExtractStage(IngestStage):
         # return dictionary of all dataframes keyed by extract config paths
         return output
 
-    def _postrun_tally(self, run_output):
+    def _postrun_discovery(self, run_output):
         """
-        See the docstring for IngestStage._postrun_tally.
+        See the docstring for IngestStage._postrun_discovery.
         """
         sources = defaultdict(
             lambda: defaultdict(set)

--- a/kf_lib_data_ingest/etl/ingest_pipeline.py
+++ b/kf_lib_data_ingest/etl/ingest_pipeline.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 import os
+import sys
 from pprint import pformat
 
 import kf_lib_data_ingest.etl.stage_analyses as stage_analyses
@@ -157,6 +158,7 @@ class DataIngestPipeline(object):
         self.stage_outputs = {}
         self.stage_discovery_sources = {}
         self.stage_discovery_links = {}
+        passed = True
 
         # Top level exception handler
         # Catch exception, log it to file and console, and exit
@@ -194,16 +196,19 @@ class DataIngestPipeline(object):
                     )
 
                     stage.logger.info("Begin Basic Stage Output Validation")
-                    self.check_stage_counts(stage_type, stage.logger)
+                    passed = (
+                        passed
+                        and self.check_stage_counts(stage_type, stage.logger)
+                    )
                     stage.logger.info("End Basic Stage Output Validation")
-
         except Exception as e:
             self.logger.exception(str(e))
             self.logger.info('Exiting.')
-            exit(1)
+            sys.exit(1)
 
         # Log the end of the run
         self.logger.info('END data ingestion')
+        return not passed
 
     def check_stage_counts(self, stage_type, logger):
         """

--- a/kf_lib_data_ingest/etl/ingest_pipeline.py
+++ b/kf_lib_data_ingest/etl/ingest_pipeline.py
@@ -202,7 +202,7 @@ class DataIngestPipeline(object):
         Do some standard stage discovery tests
         """
 
-        logger.info("Begin Basic Analysis")
+        logger.info("Begin stage output data validation")
 
         passed_all = True
         if not concept_discovery_dict:

--- a/kf_lib_data_ingest/etl/ingest_pipeline.py
+++ b/kf_lib_data_ingest/etl/ingest_pipeline.py
@@ -208,7 +208,7 @@ class DataIngestPipeline(object):
 
         # Log the end of the run
         self.logger.info('END data ingestion')
-        return not passed
+        return passed
 
     def check_stage_counts(self, stage_type, logger):
         """

--- a/kf_lib_data_ingest/etl/load/load.py
+++ b/kf_lib_data_ingest/etl/load/load.py
@@ -70,6 +70,9 @@ class LoadStage(IngestStage):
         # class
         pass
 
+    def _postrun_concept_discovery(self, run_output):
+        pass  # TODO
+
     def _run(self, target_entities):
         # TODO: revisit maybe?
         for entity_type, entities in target_entities.items():

--- a/kf_lib_data_ingest/etl/stage_analyses.py
+++ b/kf_lib_data_ingest/etl/stage_analyses.py
@@ -9,21 +9,18 @@ from kf_lib_data_ingest.etl.load.load import LoadStage
 from kf_lib_data_ingest.etl.transform.transform import TransformStage
 
 
-def check_counts(tally, expected_counts):
+def check_counts(tally_sources, expected_counts):
     """
     Verify that we found as many unique values of each attribute as we expected
     to find.
 
     :param tally: structure returned from IngestStage._postrun_tally
     :param expected_counts: dict mapping concept keys to their expected counts
+
+    :return: all checks passed (bool), output message to emit/log (str)
     """
-    if not tally or not tally.get('sources'):
-        return True, 'Tally Not Found ❌'
-
-    tallied = tally['sources']
-
     uniques = {
-        key: len(unique_vals) for key, unique_vals in tallied.items()
+        key: len(unique_vals) for key, unique_vals in tally_sources.items()
     }
 
     # display unique counts
@@ -51,12 +48,12 @@ def check_counts(tally, expected_counts):
             # Accept both concepts and attributes, but automatically
             # translate lone concepts as meaning id or else unique_key if
             # one of those was discovered in the data.
-            if key not in tallied:
+            if key not in tally_sources:
                 if key in str_to_CONCEPT:
                     concept = str_to_CONCEPT[key]
-                    if concept.ID in tallied:
+                    if concept.ID in tally_sources:
                         key = concept.ID
-                    elif concept.UNIQUE_KEY in tallied:
+                    elif concept.UNIQUE_KEY in tally_sources:
                         key = concept.UNIQUE_KEY
 
             found = uniques.get(key)
@@ -80,3 +77,7 @@ def check_counts(tally, expected_counts):
         )
 
     return passed, '\n'.join(message)
+
+
+def compare_counts(tally_sources_one, tally_sources_two):
+    False, "Compare Counts NYI"

--- a/kf_lib_data_ingest/etl/stage_analyses.py
+++ b/kf_lib_data_ingest/etl/stage_analyses.py
@@ -9,18 +9,19 @@ from kf_lib_data_ingest.etl.load.load import LoadStage
 from kf_lib_data_ingest.etl.transform.transform import TransformStage
 
 
-def check_counts(tally_sources, expected_counts):
+def check_counts(discovery_sources, expected_counts):
     """
     Verify that we found as many unique values of each attribute as we expected
     to find.
 
-    :param tally: structure returned from IngestStage._postrun_tally
+    :param discovery_sources: 'sources' subcomponent of the structure returned
+     from IngestStage._postrun_concept_discovery_postrun_concept_discovery
     :param expected_counts: dict mapping concept keys to their expected counts
 
     :return: all checks passed (bool), output message to emit/log (str)
     """
     uniques = {
-        key: len(unique_vals) for key, unique_vals in tally_sources.items()
+        key: len(unique_vals) for key, unique_vals in discovery_sources.items()
     }
 
     # display unique counts
@@ -48,12 +49,12 @@ def check_counts(tally_sources, expected_counts):
             # Accept both concepts and attributes, but automatically
             # translate lone concepts as meaning id or else unique_key if
             # one of those was discovered in the data.
-            if key not in tally_sources:
+            if key not in discovery_sources:
                 if key in str_to_CONCEPT:
                     concept = str_to_CONCEPT[key]
-                    if concept.ID in tally_sources:
+                    if concept.ID in discovery_sources:
                         key = concept.ID
-                    elif concept.UNIQUE_KEY in tally_sources:
+                    elif concept.UNIQUE_KEY in discovery_sources:
                         key = concept.UNIQUE_KEY
 
             found = uniques.get(key)
@@ -79,5 +80,5 @@ def check_counts(tally_sources, expected_counts):
     return passed, '\n'.join(message)
 
 
-def compare_counts(tally_sources_one, tally_sources_two):
+def compare_counts(discovery_sources_one, discovery_sources_two):
     False, "Compare Counts NYI"

--- a/kf_lib_data_ingest/etl/stage_analyses.py
+++ b/kf_lib_data_ingest/etl/stage_analyses.py
@@ -1,0 +1,82 @@
+from pprint import pformat
+
+import pandas
+from tabulate import tabulate
+
+from kf_lib_data_ingest.common.concept_schema import str_to_CONCEPT
+from kf_lib_data_ingest.etl.extract.extract import ExtractStage
+from kf_lib_data_ingest.etl.load.load import LoadStage
+from kf_lib_data_ingest.etl.transform.transform import TransformStage
+
+
+def check_counts(tally, expected_counts):
+    """
+    Verify that we found as many unique values of each attribute as we expected
+    to find.
+
+    :param tally: structure returned from IngestStage._postrun_tally
+    :param expected_counts: dict mapping concept keys to their expected counts
+    """
+    if not tally or not tally.get('sources'):
+        return True, 'Tally Not Found ❌'
+
+    tallied = tally['sources']
+
+    uniques = {
+        key: len(unique_vals) for key, unique_vals in tallied.items()
+    }
+
+    # display unique counts
+
+    message = ['UNIQUE COUNTS']
+    message.append(
+        pformat(uniques)
+    )
+    message.append('')
+
+    # check expected counts
+
+    passed = True
+    message.append('EXPECTED COUNT CHECKS')
+
+    if not expected_counts:
+        message.append("No expected counts registered. ❌")
+        passed = False
+    else:
+        checks = pandas.DataFrame(
+            columns=['key', 'expected', 'found', 'equal']
+        )
+        for key, expected in expected_counts.items():
+
+            # Accept both concepts and attributes, but automatically
+            # translate lone concepts as meaning id or else unique_key if
+            # one of those was discovered in the data.
+            if key not in tallied:
+                if key in str_to_CONCEPT:
+                    concept = str_to_CONCEPT[key]
+                    if concept.ID in tallied:
+                        key = concept.ID
+                    elif concept.UNIQUE_KEY in tallied:
+                        key = concept.UNIQUE_KEY
+
+            found = uniques.get(key)
+            if expected == found:
+                passmark = '✅'
+            else:
+                passed = False
+                passmark = '❌'
+            checks = checks.append(
+                {
+                    'key': key, 'expected': expected, 'found': found,
+                    'equal': passmark
+                },
+                ignore_index=True
+            )
+        message.append(
+            tabulate(
+                checks,
+                headers='keys', showindex=False, tablefmt='psql'
+            )
+        )
+
+    return passed, '\n'.join(message)

--- a/kf_lib_data_ingest/etl/transform/transform.py
+++ b/kf_lib_data_ingest/etl/transform/transform.py
@@ -282,6 +282,13 @@ class TransformStage(IngestStage):
 
         return target_instances
 
+    def _postrun_tally(self, run_output):
+        """
+        See the docstring for IngestStage._postrun_tally.
+        """
+        # TODO: Implement after transform (or an intermediate stage) is fixed
+        # to produce output using CONCEPT keys, instead of target service keys.
+
     def _insert_unique_keys(
         self, df_dict, unique_key_composition=DEFAULT_KEY_COMP
     ):

--- a/kf_lib_data_ingest/etl/transform/transform.py
+++ b/kf_lib_data_ingest/etl/transform/transform.py
@@ -282,9 +282,9 @@ class TransformStage(IngestStage):
 
         return target_instances
 
-    def _postrun_tally(self, run_output):
+    def _postrun_discovery(self, run_output):
         """
-        See the docstring for IngestStage._postrun_tally.
+        See the docstring for IngestStage._postrun_discovery.
         """
         # TODO: Implement after transform (or an intermediate stage) is fixed
         # to produce output using CONCEPT keys, instead of target service keys.

--- a/kf_lib_data_ingest/etl/transform/transform.py
+++ b/kf_lib_data_ingest/etl/transform/transform.py
@@ -282,12 +282,13 @@ class TransformStage(IngestStage):
 
         return target_instances
 
-    def _postrun_discovery(self, run_output):
+    def _postrun_concept_discovery(self, run_output):
         """
-        See the docstring for IngestStage._postrun_discovery.
+        See the docstring for IngestStage._postrun_concept_discovery.
         """
         # TODO: Implement after transform (or an intermediate stage) is fixed
         # to produce output using CONCEPT keys, instead of target service keys.
+        pass  # TODO
 
     def _insert_unique_keys(
         self, df_dict, unique_key_composition=DEFAULT_KEY_COMP

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ networkx==2.1
 xlrd==1.1.0
 requests==2.21.0
 tabulate==0.8.3
+jsonpickle==1.1

--- a/tests/test_extract_stage.py
+++ b/tests/test_extract_stage.py
@@ -73,7 +73,7 @@ def test_extracts():
     for study_dir, study_configs in expected_results.items():
         extract_configs = list(study_configs.keys())
         es = ExtractStage(os.path.join(study_dir, 'output'), extract_configs)
-        df_out, _, _ = es.run()
+        df_out, _ = es.run()
         recycled_output = es.read_output()
 
         for config in extract_configs:

--- a/tests/test_ingest_pipeline.py
+++ b/tests/test_ingest_pipeline.py
@@ -39,6 +39,17 @@ def test_ingest():
     assert 'BEGIN data ingestion' in result.output
     assert 'END data ingestion' in result.output
 
+    # Make sure that post-extract counts run
+    assert (
+        'ExtractStage - INFO - Begin Basic Stage Output Validation'
+        in result.output
+    )
+    assert 'ExtractStage - INFO - UNIQUE COUNTS' in result.output
+    assert (
+        '| CONCEPT|BIOSPECIMEN|ID |         60 |      60 | ✅      |'
+        in result.output
+    )
+
 
 def test_ingest_no_transform_module(tmpdir):
     """

--- a/tests/test_ingest_pipeline.py
+++ b/tests/test_ingest_pipeline.py
@@ -35,7 +35,7 @@ def test_ingest():
     runner = CliRunner()
     result = runner.invoke(cli.ingest, [ingest_config_path])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert 'BEGIN data ingestion' in result.output
     assert 'END data ingestion' in result.output
 

--- a/tests/test_ingest_stage.py
+++ b/tests/test_ingest_stage.py
@@ -17,6 +17,9 @@ def ValidIngestStage():
         def _run(self, foo):
             return foo
 
+        def _postrun_concept_discovery(self, run_output):
+            pass
+
         def _validate_run_parameters(self, foo):
             if not foo:
                 raise InvalidIngestStageParameters
@@ -56,6 +59,9 @@ def test_invalid_run_parameters():
     # Test that InvalidIngestStageParameters excp raised on invalid run params
     class ValidIngestStage(IngestStage):
         def _run(self, foo):
+            pass
+
+        def _postrun_concept_discovery(self, run_output):
             pass
 
         def _validate_run_parameters(self, foo):

--- a/tests/test_ingest_stage.py
+++ b/tests/test_ingest_stage.py
@@ -104,7 +104,7 @@ def test_stage_read_write(ValidIngestStage):
     # Test output is written and read when stage_cache_dir is defined
     stage = ValidIngestStage(ingest_output_dir=TEST_INGEST_OUTPUT_DIR)
     run_input = 'hello world'
-    run_output, _, _ = stage.run(run_input)
+    run_output, _ = stage.run(run_input)
     assert stage.read_output() == run_output
 
 

--- a/tests/test_transform_stage.py
+++ b/tests/test_transform_stage.py
@@ -53,7 +53,7 @@ def test_read_write(guided_transform_stage, df):
     extract_output = {'extract_config_url': ('source_url', df)}
 
     # Transform outputs json
-    output, _, _ = guided_transform_stage.run(extract_output)
+    output, _ = guided_transform_stage.run(extract_output)
     recycled_output = guided_transform_stage.read_output()
 
     for target_entity, data in output.items():


### PR DESCRIPTION
We can separate tallying from actual analysis and then do the analysis in a more controlled and comparable way.

Make a uniform stage tally format that each stage is repsonsible for building, and then we can give that to whatever tests we want.