### PR TITLE
🐛 Fix rogue nulls

### DIFF
--- a/kf_lib_data_ingest/etl/transform/guided.py
+++ b/kf_lib_data_ingest/etl/transform/guided.py
@@ -142,12 +142,15 @@ class GuidedTransformStage(TransformStage):
             df = all_data_df.drop_duplicates(subset=std_concept_ukey)
 
             # Build target instances for target_concept (i.e. participant)
-            total = df.shape[0]
-            self.logger.info(f'Building {total} {target_concept} concepts ...')
+            self.logger.info(f'Building {target_concept} concepts ...')
             for _, row in df.iterrows():
                 target_instance = {}
                 # id
                 target_instance['id'] = row[std_concept_ukey]
+
+                # Skip building target instances with null ids
+                if not target_instance['id']:
+                    continue
 
                 # endpoint
                 target_instance['endpoint'] = config['endpoint']
@@ -168,6 +171,9 @@ class GuidedTransformStage(TransformStage):
                             'links'][target_attr] = row.get(std_concept_attr)
 
                 target_instances[target_concept].append(target_instance)
+
+            self.logger.info(f'Built {len(target_instances[target_concept])} '
+                             f'{target_concept} concepts')
 
         return target_instances
 

--- a/tests/test_guided_transform.py
+++ b/tests/test_guided_transform.py
@@ -27,7 +27,11 @@ def all_data_df():
         }),
         'participant': pd.DataFrame({
             CONCEPT.PARTICIPANT.UNIQUE_KEY: ['p1', 'p2', 'p2'],
+            CONCEPT.DIAGNOSIS.NAME: ['cold', 'cold', None],
             CONCEPT.PARTICIPANT.GENDER: ['Female', 'Male', 'Female']
+        }),
+        'diagnosis': pd.DataFrame({
+            CONCEPT.DIAGNOSIS.UNIQUE_KEY: ['p1-cold', 'p2-cold', None]
         }),
         'biospecimen': pd.DataFrame({
             CONCEPT.PARTICIPANT.UNIQUE_KEY: ['p1', 'p2', 'p2'],
@@ -80,7 +84,7 @@ def test_standard_to_target_transform(caplog, all_data_df,
     # Check instances counts and values
     for target_concept, instances in target_instances.items():
         # Only 2 unique participants
-        if target_concept == 'participant':
+        if target_concept == 'participant' or target_concept == 'diagnosis':
             assert len(instances) == 2
         else:
             assert 3 == len(instances)


### PR DESCRIPTION
Fix unique key generation 
- Only build unique key strings if all required cols are present and the values are not null. 
- For optional cols that are null, use a value of Not Reported in the unique key string

Fix standard to target instance building
- Don't build target instances with a null id