### PR TITLE
♻️ Make target api file fields, class var names consistent

### DIFF
--- a/kf_lib_data_ingest/etl/configuration/target_api_config.py
+++ b/kf_lib_data_ingest/etl/configuration/target_api_config.py
@@ -131,7 +131,7 @@ class TargetAPIConfig(PyModuleConfig):
         Import python module, validate it, and populate instance attributes
         """
         super().__init__(filepath)
-        self.concept_schemas = self.contents.target_concepts
+        self.target_concepts = self.contents.target_concepts
         self.relationship_graph = self._build_relationship_graph(
             self.contents.relationships)
 

--- a/kf_lib_data_ingest/etl/transform/guided.py
+++ b/kf_lib_data_ingest/etl/transform/guided.py
@@ -127,7 +127,7 @@ class GuidedTransformStage(TransformStage):
 
         target_instances = defaultdict(list)
         for (target_concept,
-             config) in self.target_api_config.concept_schemas.items():
+             config) in self.target_api_config.target_concepts.items():
 
             # Unique key for the target concept must exist
             standard_concept = config.get('standard_concept')

--- a/kf_lib_data_ingest/etl/transform/standard_model/model.py
+++ b/kf_lib_data_ingest/etl/transform/standard_model/model.py
@@ -33,10 +33,10 @@ class StandardModel(object):
         # Use whole concept set if target concepts are not supplied
         if not target_concepts_to_transform:
             target_concepts_to_transform = (target_api_config
-                                            .concept_schemas.keys())
+                                            .target_concepts.keys())
 
         # The schemas of the target concepts
-        schemas = target_api_config.concept_schemas
+        schemas = target_api_config.target_concepts
         # The networkx graph containing how target concepts are related
         relation_graph = target_api_config.relationship_graph
 

--- a/kf_lib_data_ingest/etl/transform/transform.py
+++ b/kf_lib_data_ingest/etl/transform/transform.py
@@ -138,9 +138,9 @@ class TransformStage(IngestStage):
         format of target_schema
 
         `target_instances` is a dict keyed by the `target_concepts` defined in
-        this `target_api_config.concept_schemas`. The values are lists of
+        this `target_api_config.target_concepts`. The values are lists of
         dicts, where a dict in the list takes on the same form as the dicts in
-        `target_api_config.concept_schemas`.
+        `target_api_config.target_concepts`.
 
         For example, `target_instances` might look like:
 

--- a/tests/test_guided_transform.py
+++ b/tests/test_guided_transform.py
@@ -96,7 +96,7 @@ def test_standard_to_target_transform(caplog, all_data_df,
 
     # Check log output
     no_data_concepts = (
-        set(guided_transform_stage.target_api_config.concept_schemas.keys())
+        set(guided_transform_stage.target_api_config.target_concepts.keys())
         .symmetric_difference(set(expected_concepts))
     )
     no_unique_key_msg = 'No unique key found in table for target concept:'

--- a/tests/test_null_processing.py
+++ b/tests/test_null_processing.py
@@ -55,7 +55,7 @@ def schema(tmpdir, target_api_config, **kwargs):
     cached_schema_file = os.path.join(tmpdir, 'cached_schema.json')
     output = get_open_api_v2_schema(
         KIDSFIRST_DATASERVICE_PROD_URL,
-        target_api_config.concept_schemas.keys(),
+        target_api_config.target_concepts.keys(),
         cached_schema_filepath=cached_schema_file)
 
     return output
@@ -103,7 +103,7 @@ def test_get_kf_schema(caplog, tmpdir, target_api_config, **kwargs):
     cached_schema_file = os.path.join(tmpdir, 'cached_schema.json')
     output = get_open_api_v2_schema(
         KIDSFIRST_DATASERVICE_PROD_URL,
-        target_api_config.concept_schemas.keys(),
+        target_api_config.target_concepts.keys(),
         cached_schema_filepath=cached_schema_file)
     assert output.get('definitions')
     assert output.get('version')
@@ -114,7 +114,7 @@ def test_get_kf_schema(caplog, tmpdir, target_api_config, **kwargs):
     mock.get(schema_url, status_code=500)
     output = get_open_api_v2_schema(
         KIDSFIRST_DATASERVICE_PROD_URL,
-        target_api_config.concept_schemas.keys(),
+        target_api_config.target_concepts.keys(),
         cached_schema_filepath=cached_schema_file)
     assert output.get('definitions')
     assert output.get('version')
@@ -124,7 +124,7 @@ def test_get_kf_schema(caplog, tmpdir, target_api_config, **kwargs):
     mock.get(schema_url, json=mock_dataservice_schema)
     output = get_open_api_v2_schema(
         KIDSFIRST_DATASERVICE_PROD_URL,
-        target_api_config.concept_schemas.keys())
+        target_api_config.target_concepts.keys())
     assert os.path.isfile(os.path.realpath('./cached_schema.json'))
 
 

--- a/tests/test_standard_model.py
+++ b/tests/test_standard_model.py
@@ -171,7 +171,7 @@ def test_transform_all(target_api_config, random_model):
     # Output should only include the concepts for which there is data
     data = random_model.transform(target_api_config,
                                   target_concepts_to_transform=None)
-    all_target_concepts = target_api_config.concept_schemas.keys()
+    all_target_concepts = target_api_config.target_concepts.keys()
     target_concepts_w_data = ['family', 'participant', 'biospecimen']
 
     for target_concept, output in data.items():
@@ -202,7 +202,7 @@ def test_transform(target_api_config, random_model):
     # of id nodes for that concept in the concept graph
     for target_concept, instances in data.items():
         # Get standard concept this target concept maps to
-        schema = target_api_config.concept_schemas[target_concept]
+        schema = target_api_config.target_concepts[target_concept]
         standard_concept = schema['standard_concept']._CONCEPT_NAME
 
         # Check counts


### PR DESCRIPTION
kids_first.py was calling it target_concepts
target_api_config.py class was calling concept_schemas

Make them both target_concepts