### PR TITLE
✨ Remove need to manually forward config elements

### DIFF
--- a/kf_lib_data_ingest/etl/configuration/base_config.py
+++ b/kf_lib_data_ingest/etl/configuration/base_config.py
@@ -29,6 +29,10 @@ class AbstractConfig(ABC):
                 f'{self.config_filepath} failed validation'
             ) from e
 
+    def __getattr__(self, attr):
+        """ Forward attributes from self.contents """
+        return getattr(self.contents, attr)
+
     @abstractmethod
     def _read_file(self, filepath):
         """ Should raise a FileNotFoundError exception if file not exists """

--- a/kf_lib_data_ingest/etl/configuration/base_config.py
+++ b/kf_lib_data_ingest/etl/configuration/base_config.py
@@ -31,7 +31,15 @@ class AbstractConfig(ABC):
 
     def __getattr__(self, attr):
         """ Forward attributes from self.contents """
-        return getattr(self.contents, attr)
+        try:
+            try:
+                return self.contents[attr]
+            except Exception:
+                return getattr(self.contents, attr)
+        except Exception:
+            raise AttributeError(
+                f"'{self.config_filepath}' has no attribute '{attr}'"
+            )
 
     @abstractmethod
     def _read_file(self, filepath):

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -6,7 +6,8 @@ from conftest import TEST_DATA_DIR
 from kf_lib_data_ingest.etl.configuration.base_config import (
     AbstractConfig,
     ConfigValidationError,
-    YamlConfig
+    YamlConfig,
+    PyModuleConfig
 )
 
 
@@ -51,6 +52,15 @@ def test_yaml_config():
 
     config_path = os.path.join(TEST_DATA_DIR, 'valid_yaml_config.yml')
     YamlConfig(config_path, schema_path=schema_path)
+
+
+def test_attr_forwarding():
+    pmc = PyModuleConfig(
+        os.path.join(TEST_DATA_DIR, 'test_study', 'transform_module.py')
+    )
+    assert pmc.contents.transform_function == pmc.transform_function
+    with pytest.raises(AttributeError):
+        print(pmc.foo)
 
 
 def test_extract_config():

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -62,6 +62,13 @@ def test_attr_forwarding():
     with pytest.raises(AttributeError):
         print(pmc.foo)
 
+    config_path = os.path.join(TEST_DATA_DIR, 'valid_yaml_config.yml')
+    schema_path = os.path.join(TEST_DATA_DIR, 'yaml_schema.yml')
+    yc = YamlConfig(config_path, schema_path=schema_path)
+    assert yc.contents.get('params') == yc.params
+    with pytest.raises(AttributeError):
+        print(yc.foo)
+
 
 def test_extract_config():
     pass


### PR DESCRIPTION
I don't think we should need to manually forward everything we want to use from a config file.

See e.g.

`self.target_concepts = self.contents.target_concepts` in TargetAPIConfig.__init__
