### PR TITLE
♻️ Make template ingest pkg usable

### DIFF
--- a/kf_lib_data_ingest/factory/templates/my_study/data/clinical.tsv
+++ b/kf_lib_data_ingest/factory/templates/my_study/data/clinical.tsv
@@ -1,0 +1,6 @@
+family	subject	sample	analyte	diagnosis	gender
+f1	p1	b1	dna	flu	Male
+f1	p2	b2	rna	cold	Female
+f1	p2	b3	dna	cold	Female
+f2	p3	b4	dna	cold	Female
+f2	p4	b5	rna	strep throat	Male

--- a/kf_lib_data_ingest/factory/templates/my_study/dataset_ingest_config.yml
+++ b/kf_lib_data_ingest/factory/templates/my_study/dataset_ingest_config.yml
@@ -25,6 +25,12 @@ extract_config_dir: 'extract_configs'
 
 transform_function_path: 'transform_module.py'
 
+# TODO - Replace these with your own valid values
+expected_counts:
+    'CONCEPT|FAMILY': 2
+    'CONCEPT|PARTICIPANT': 4
+    'CONCEPT|BIOSPECIMEN': 5
+
 
 # TODO - Replace these values with your own valid values!
 study:

--- a/kf_lib_data_ingest/factory/templates/my_study/extract_configs/extract_config.py
+++ b/kf_lib_data_ingest/factory/templates/my_study/extract_configs/extract_config.py
@@ -12,12 +12,37 @@ from kf_lib_data_ingest.common.concept_schema import (
     CONCEPT
 )
 
-# TODO Fill in valid URL to source data file here
-source_data_url = ''
+# TODO - Replace this with a URL to your own data file
+source_data_url = 'file://../data/clinical.tsv'
 
 # TODO (Optional) Fill in special loading parameters here
 source_data_loading_parameters = {}
 
 
-# TODO Fill in extract operations here
-operations = []
+# TODO - Replace this with operations that make sense for your own data file
+operations = [
+    keep_map(
+        in_col='family',
+        out_col=CONCEPT.FAMILY.ID
+    ),
+    keep_map(
+        in_col='subject',
+        out_col=CONCEPT.PARTICIPANT.ID
+    ),
+    keep_map(
+        in_col='gender',
+        out_col=CONCEPT.PARTICIPANT.GENDER
+    ),
+    keep_map(
+        in_col='sample',
+        out_col=CONCEPT.BIOSPECIMEN.ID
+    ),
+    keep_map(
+        in_col='analyte',
+        out_col=CONCEPT.BIOSPECIMEN.ANALYTE
+    ),
+    keep_map(
+        in_col='diagnosis',
+        out_col=CONCEPT.DIAGNOSIS.NAME
+    )
+]

--- a/kf_lib_data_ingest/factory/templates/my_study/transform_module.py
+++ b/kf_lib_data_ingest/factory/templates/my_study/transform_module.py
@@ -11,7 +11,7 @@ implementing transform_function.
 # Use these merge funcs, not pandas.merge
 from kf_lib_data_ingest.common.pandas_utils import (
     outer_merge,
-    merge_without_duplicates
+    merge_wo_duplicates
 )
 
 

--- a/tests/test_create_new_ingest.py
+++ b/tests/test_create_new_ingest.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import filecmp
+import logging
 
 import pytest
 from click.testing import CliRunner
@@ -58,7 +59,11 @@ def test_new_ingest_already_exists(tmpdir):
     assert dest_dir is None
 
 
-def test_ingest_template_study(tmpdir):
+def test_ingest_template_study(caplog, tmpdir):
+    """
+    Test ingest runs successfully for the template package
+    """
+    caplog.set_level(logging.INFO)
     # > kidsfirst new
     study_dir = os.path.join(tmpdir, 'my_study')
     runner = CliRunner()
@@ -68,3 +73,10 @@ def test_ingest_template_study(tmpdir):
     assert os.path.isdir(study_dir)
     # No exceptions raised
     assert result.exit_code == 0
+
+    # Run ingest on the generated template package
+    result = runner.invoke(cli.ingest, [study_dir])
+    assert result.exit_code == 0
+    assert 'EXPECTED COUNT CHECKS' in caplog.text
+    assert 'END data ingestion'
+    assert os.path.isdir(os.path.join(study_dir, 'output'))


### PR DESCRIPTION
In preparation for #188 

Update the template ingest package so that it will successfully run through the ingest pipeline after its generated via `kidsfirst new` command

Added 1 source data file, 1 working extract config, a working transform module, and expected counts