### PR TITLE
🐛 Fix bug with optional components in unique keys

### DIFF
--- a/kf_lib_data_ingest/common/concept_schema.py
+++ b/kf_lib_data_ingest/common/concept_schema.py
@@ -292,7 +292,7 @@ def _create_unique_key_composition():
         ],
         'optional': [
             CONCEPT.PHENOTYPE.OBSERVED,
-            CONCEPT.DIAGNOSIS.EVENT_AGE_DAYS
+            CONCEPT.PHENOTYPE.EVENT_AGE_DAYS
         ]
     }
     identifiers[CONCEPT.OUTCOME._CONCEPT_NAME] = {

--- a/kf_lib_data_ingest/etl/transform/transform.py
+++ b/kf_lib_data_ingest/etl/transform/transform.py
@@ -478,12 +478,15 @@ class TransformStage(IngestStage):
             def make_unique_key_value(row):
                 values = []
                 for c in unique_key_cols:
-                    # Col is not in df
-                    if c not in row:
-                        return None
                     # Col is required to make unique key but is null
                     if c in required and pandas.isnull(row[c]):
                         return None
+
+                    # Optional col is not in df,
+                    # fill in with constants.COMMON.NOT_REPORTED
+                    if (c in optional) and c not in row:
+                        row[c] = constants.COMMON.NOT_REPORTED
+
                     # Optional cols whose values are null will be converted
                     # to constants.COMMON.NOT_REPORTED
                     values.append(

--- a/tests/test_transform_stage.py
+++ b/tests/test_transform_stage.py
@@ -202,8 +202,11 @@ def test_no_key_comp_defined(guided_transform_stage):
 
 def test_nulls_in_unique_keys(guided_transform_stage):
     """
-    If any subvalue of the unique key string is null,
+    If any required subvalue of the unique key string is null,
     then the resulting value of the unique key should be None
+
+    If any optional subvalue of the unique key string is null,
+    then it should have been replaced with constants.COMMON.NOT_REPORTED
     """
 
     dfs = {
@@ -215,6 +218,7 @@ def test_nulls_in_unique_keys(guided_transform_stage):
             CONCEPT.PARTICIPANT.ID: ['p1', 'p2', 'p3'],
             CONCEPT.PARTICIPANT.GENDER: ['Female', 'Male', 'Female'],
             CONCEPT.DIAGNOSIS.NAME: ['cold', 'flu', 'strep'],
+            CONCEPT.PHENOTYPE.NAME: ['extra ear', 'enlarged ear', 'extra lip'],
             CONCEPT.DIAGNOSIS.EVENT_AGE_DAYS: [300, 400, None]
         }),
         'biospecimen': pd.DataFrame({
@@ -259,4 +263,13 @@ def test_nulls_in_unique_keys(guided_transform_stage):
     assert(
         df[CONCEPT.DIAGNOSIS.UNIQUE_KEY].values.tolist() ==
         ['p1-cold-300', 'p2-flu-400', 'p3-strep-Not Reported']
+    )
+
+    # Test compound unique key with missing optional components
+    print(df[CONCEPT.PHENOTYPE.UNIQUE_KEY].values.tolist())
+    assert(
+        df[CONCEPT.PHENOTYPE.UNIQUE_KEY].values.tolist() ==
+        ['p1-extra ear-Not Reported-Not Reported',
+         'p2-enlarged ear-Not Reported-Not Reported',
+         'p3-extra lip-Not Reported-Not Reported']
     )


### PR DESCRIPTION
- Fix typo in phenotype unique key composition
- Fix unique key generation 
For a unique key with optional cols, if the col is missing or the col is present but the value is missing, fill in with Not Reported