### PR TITLE
🐳 Docker container clean up after ingest ends

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -23,3 +23,13 @@ if [[ $KF_INGEST_APP_MODE = "production" ]]; then
 fi
 
 kidsfirst "$@"
+
+# During deployment - rm ingest package after ingest completes
+if [[ $CLEANUP ]]; then
+    PACKAGE_DIR="/data/packages/$CLEANUP"
+    if [[ -d $PACKAGE_DIR ]]; then
+        echo "Deleting ingest $PACKAGE_DIR ..."
+        rm -rf $PACKAGE_DIR
+        echo "Complete"
+    fi
+fi

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -30,15 +30,18 @@ if [[ $? -ne 0 ]]; then
     INGEST_ERROR=1
 fi
 
-# During deployment - rm ingest package after ingest completes
-if [[ $CLEANUP ]]; then
-    INGEST_PACKAGE_DIR="/data/packages/$CLEANUP"
+# If container was run by automated process - rm ingest package after ingest completes
+if [[ "$DELETE_INGEST_PKG" = true ]] && [[ "$INGEST_PKG_TO_DEL" ]]; then
+    INGEST_PACKAGE_DIR="/data/packages/$INGEST_PKG_TO_DEL"
+
     if [[ -d $INGEST_PACKAGE_DIR ]]; then
         echo "Start cleanup ..."
         echo "Deleting ingest package $INGEST_PACKAGE_DIR"
-        rm -rf $INGEST_PACKAGE_DIR
+        rm -rf "$INGEST_PACKAGE_DIR"
         echo "Cleanup Complete"
     fi
+else
+    echo "Skipping ingest package clean up"
 fi
 
 if [[ $INGEST_ERROR -ne 0 ]]; then

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -22,14 +22,26 @@ if [[ $KF_INGEST_APP_MODE = "production" ]]; then
     fi
 fi
 
+INGEST_ERROR=0
+
 kidsfirst "$@"
+
+if [[ $? -ne 0 ]]; then
+    INGEST_ERROR=1
+fi
 
 # During deployment - rm ingest package after ingest completes
 if [[ $CLEANUP ]]; then
-    PACKAGE_DIR="/data/packages/$CLEANUP"
-    if [[ -d $PACKAGE_DIR ]]; then
-        echo "Deleting ingest $PACKAGE_DIR ..."
-        rm -rf $PACKAGE_DIR
-        echo "Complete"
+    INGEST_PACKAGE_DIR="/data/packages/$CLEANUP"
+    if [[ -d $INGEST_PACKAGE_DIR ]]; then
+        echo "Start cleanup ..."
+        echo "Deleting ingest package $INGEST_PACKAGE_DIR"
+        rm -rf $INGEST_PACKAGE_DIR
+        echo "Cleanup Complete"
     fi
+fi
+
+if [[ $INGEST_ERROR -ne 0 ]]; then
+    echo "Error in docker entrypoint exiting with 1!"
+    exit 1
 fi


### PR DESCRIPTION
**Problem**
Docker container runs as root user or a user different than Jenkins user. When we run the container in the kf-ingest-packages CI pipeline on Jenkins host, we need to bind mount the kf-ingest-packages/kf_ingest_packages/packages directory into the container. When container is running ingest it writes logs/outputs as root into that bind mounted directory. When Jenkins tries to do its usual clean up it tries to delete the kf-ingest-packages/packages directory which contains logs/outputs that are owned by root.

**Solution**
Update docker container entrypoint so that it optionally cleans up (rm -rf) the ingest package dir after ingest finishes or fails. This is controlled by the CLEANUP env var which will contain the package name to delete. This is used in the CI script for kf-ingest-packages. 