### PR TITLE
🔥 Rm docker self clean from entrypoint

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [[ $KF_INGEST_APP_MODE = "production" ]]; then
     echo "Loading production app settings into environment ..."
 
@@ -22,29 +24,4 @@ if [[ $KF_INGEST_APP_MODE = "production" ]]; then
     fi
 fi
 
-INGEST_ERROR=0
-
 kidsfirst "$@"
-
-if [[ $? -ne 0 ]]; then
-    INGEST_ERROR=1
-fi
-
-# If container was run by automated process - rm ingest package after ingest completes
-if [[ "$DELETE_INGEST_PKG" = true ]] && [[ "$INGEST_PKG_TO_DEL" ]]; then
-    INGEST_PACKAGE_DIR="/data/packages/$INGEST_PKG_TO_DEL"
-
-    if [[ -d $INGEST_PACKAGE_DIR ]]; then
-        echo "Start cleanup ..."
-        echo "Deleting ingest package $INGEST_PACKAGE_DIR"
-        rm -rf "$INGEST_PACKAGE_DIR"
-        echo "Cleanup Complete"
-    fi
-else
-    echo "Skipping ingest package clean up"
-fi
-
-if [[ $INGEST_ERROR -ne 0 ]]; then
-    echo "Error in docker entrypoint exiting with 1!"
-    exit 1
-fi


### PR DESCRIPTION
Remove the code inside the Docker entrypoint that optionally deletes the ingest package after running ingest. 

This was needed before because during a [kf-ingest-packages](https://github.com/kids-first/kf-ingest-packages) CI scenario the Docker container needed to delete any files it produced on the host system since those files are written as root and cannot be deleted by the Jenkins user.

Not needed any more because the Docker container no longer writes files to the host system. See https://github.com/kids-first/kf-ingest-packages/pull/24