### PR TITLE
🐛 The correct auth descriptor is "Bearer" not "Token"

### DIFF
--- a/kf_lib_data_ingest/common/file_retriever.py
+++ b/kf_lib_data_ingest/common/file_retriever.py
@@ -31,6 +31,10 @@ retry.log.setLevel(logging.INFO)
 PROTOCOL_SEP = "://"
 
 
+class ConfigError(Exception):
+    pass
+
+
 def split_protocol(url):
     """
     Split file url string into protocol and path.
@@ -150,9 +154,16 @@ def _web_save(protocol, source_loc, dest_obj, auth_config=None, logger=None):
             if auth_config.get('token_location') == 'url':
                 utils.http_get_file(
                     f"{url}?{urlencode({'token': token})}", dest_obj)
-            else:
+            elif auth_config.get('token_location', 'header') == 'header':
                 utils.http_get_file(
-                    url, dest_obj, headers={'Authorization': f'Token {token}'})
+                    url, dest_obj, headers={'Authorization': f'Bearer {token}'}
+                )
+            else:
+                raise ConfigError(
+                    f"App settings auth config token_location for {url} must"
+                    " be one of: "
+                    "'header' (default) or 'url' (only use if necessary)"
+                )
 
         # OAuth 2
         elif auth_scheme == 'oauth2':

--- a/tests/test_file_retriever.py
+++ b/tests/test_file_retriever.py
@@ -210,7 +210,7 @@ def test_get_web_w_auth(caplog, tmpdir, auth_configs, url, auth_type,
                     req_headers = m.request_history[0].headers
                     auth_header = req_headers.get('Authorization')
                     assert auth_header
-                    assert f'Token {token}' in auth_header
+                    assert f'Bearer {token}' in auth_header
 
             # Oauth2 auth
             elif auth_type == 'oauth2':


### PR DESCRIPTION
See https://github.com/kids-first/kf-api-study-creator/blob/master/docs/downloads.rst#direct-download-with-headers

closes #260 