### PR TITLE
🐛 click.Choice needs a list, not an iterator

### DIFF
--- a/kf_lib_data_ingest/app/cli.py
+++ b/kf_lib_data_ingest/app/cli.py
@@ -42,8 +42,9 @@ def common_args_options(func):
         'supplied via config, the default log_level for the ingest lib will '
         f'be used: {DEFAULT_LOG_LEVEL_NAME}')
     func = click.option('--log_level', 'log_level_name',
-                        type=click.Choice(map(str.lower,
-                                              logging._nameToLevel.keys())),
+                        type=click.Choice(
+                            list(map(str.lower, logging._nameToLevel.keys()))
+                        ),
                         help=log_help_txt)(func)
     # Target URL
     func = click.option(

--- a/kf_lib_data_ingest/app/cli.py
+++ b/kf_lib_data_ingest/app/cli.py
@@ -43,7 +43,8 @@ def common_args_options(func):
         f'be used: {DEFAULT_LOG_LEVEL_NAME}')
     func = click.option('--log_level', 'log_level_name',
                         type=click.Choice(
-                            list(map(str.lower, logging._nameToLevel.keys()))
+                            [level_name.lower()
+                             for level_name in logging._nameToLevel.keys()]
                         ),
                         help=log_help_txt)(func)
     # Target URL


### PR DESCRIPTION
the click.Choice docstring says:
"You should only pass a list or tuple of choices. Other iterables
    (like generators) may lead to surprising results."

fixes #272