### PR TITLE
✨ Add grouping of Splits

### DIFF
--- a/kf_lib_data_ingest/common/misc.py
+++ b/kf_lib_data_ingest/common/misc.py
@@ -12,7 +12,10 @@ import jsonpickle
 import yaml
 from pandas import isnull
 
-from kf_lib_data_ingest.common.type_safety import assert_safe_type
+from kf_lib_data_ingest.common.type_safety import (
+    assert_all_safe_type,
+    assert_safe_type
+)
 
 
 def import_module_from_file(filepath):
@@ -239,6 +242,7 @@ def multisplit(string: str, delimiters: list):
 
     assert_safe_type(string, str)
     assert_safe_type(delimiters, list)
+    assert_all_safe_type(delimiters, str)
     regexPattern = '|'.join(map(re.escape, delimiters))
     return re.split(regexPattern, string)
 

--- a/kf_lib_data_ingest/etl/extract/extract.py
+++ b/kf_lib_data_ingest/etl/extract/extract.py
@@ -297,7 +297,7 @@ class ExtractStage(IngestStage):
         #  0       1   C             5
         #  1       2   C             6
 
-        df_out = pandas.DataFrame()
+        df_out = pandas.DataFrame(dtype=object)
         index = None
         for col_name, col_series in out_cols.items():
             if not col_series.empty:
@@ -305,7 +305,7 @@ class ExtractStage(IngestStage):
                 assert length_multiplier == round(length_multiplier)
                 # repeat the series length_multiplier times
                 df_out[col_name] = pandas.Series(
-                    list(col_series) * round(length_multiplier)
+                    list(col_series) * round(length_multiplier), dtype=object
                 )
                 col_index = list(col_series.index) * round(length_multiplier)
                 if index:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click==7.0
 jsonschema==2.6.0
 numpy==1.15.0
-pandas==0.23.3
+pandas==0.24.2
 python-dateutil==2.7.3
 pytz==2018.5
 pyyaml>=4.2b1

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -71,6 +71,7 @@ def test_overwrite_log(ingest_pipeline):
     ip.run()
     assert len(os.listdir(log_dir)) == 6
 
+
 def test_log_level(ingest_pipeline):
     """
     Test that configuration of logging level works


### PR DESCRIPTION
This lets you specify a group ID for Split objects, such that two
Splits on the same row with the same group ID will be applied
simultaneously in parallel rather than sequentially.

closes #301 