### PR TITLE
🐛 Load objects instead of object-like strings

### DIFF
--- a/kf_lib_data_ingest/etl/load/load.py
+++ b/kf_lib_data_ingest/etl/load/load.py
@@ -13,7 +13,7 @@ from requests import RequestException
 from sqlite3worker import Sqlite3Worker, sqlite3worker
 
 from kf_lib_data_ingest.common.errors import InvalidIngestStageParameters
-from kf_lib_data_ingest.common.misc import multisplit
+from kf_lib_data_ingest.common.misc import multisplit, str_to_obj
 from kf_lib_data_ingest.common.stage import IngestStage
 from kf_lib_data_ingest.network.utils import requests_retry_session
 from kf_lib_data_ingest.config import DEFAULT_ID_CACHE_FILENAME
@@ -309,8 +309,11 @@ class LoadStage(IngestStage):
             or self._get_target_id(entity_type, entity_id)
         )
 
+        # convert list/dict-like strings to their native forms and
         # don't send null attributes
-        body = {k: v for k, v in body.items() if not pandas.isnull(v)}
+        body = {
+            k: str_to_obj(v) for k, v in body.items() if not pandas.isnull(v)
+        }
 
         # link cached foreign keys
         target_concepts = self.target_api_config.target_concepts

--- a/kf_lib_data_ingest/etl/transform/transform.py
+++ b/kf_lib_data_ingest/etl/transform/transform.py
@@ -19,7 +19,7 @@ from kf_lib_data_ingest.common.concept_schema import \
     unique_key_composition as DEFAULT_KEY_COMP
 from kf_lib_data_ingest.common.errors import InvalidIngestStageParameters
 from kf_lib_data_ingest.common.misc import (
-    numeric_to_str,
+    convert_to_downcasted_str,
     read_json,
     write_json
 )
@@ -509,9 +509,11 @@ class TransformStage(IngestStage):
                     # Optional cols whose values are null will be converted
                     # to constants.COMMON.NOT_REPORTED
                     values.append(
-                        numeric_to_str(row[c],
-                                       replace_na=True,
-                                       na=constants.COMMON.NOT_REPORTED)
+                        convert_to_downcasted_str(
+                            row[c],
+                            replace_na=True,
+                            na=constants.COMMON.NOT_REPORTED
+                        )
                     )
 
                 return VALUE_DELIMITER.join(values)

--- a/tests/test_extract_stage.py
+++ b/tests/test_extract_stage.py
@@ -6,7 +6,7 @@ import requests_mock
 
 from conftest import TEST_DATA_DIR
 from kf_lib_data_ingest.common.concept_schema import CONCEPT
-from kf_lib_data_ingest.common.misc import numeric_to_str
+from kf_lib_data_ingest.common.misc import convert_to_downcasted_str
 from kf_lib_data_ingest.etl.configuration.base_config import (
     ConfigValidationError
 )
@@ -50,10 +50,10 @@ def rectify_cols_and_datatypes(A, B):
     # account for datatype mismatches induced by loading the expected
     # result directly from a file
     A = A.applymap(
-        lambda x: numeric_to_str(x, replace_na=True, na='')
+        lambda x: convert_to_downcasted_str(x, replace_na=True, na='')
     )
     B = B.applymap(
-        lambda x: numeric_to_str(x, replace_na=True, na='')
+        lambda x: convert_to_downcasted_str(x, replace_na=True, na='')
     )
 
     for col in A.columns:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,30 +1,54 @@
 import pandas
+import numpy
 
 from kf_lib_data_ingest.common.misc import *
 
 
-def test_numeric_to_str():
+def test_convert_to_str():
     df1 = pandas.DataFrame(
         {
-            'a': [1.0, 2, 3, 0.0, 0.2],
-            'b': ['1_1', ' ab ', 2, 2.56, None]
+            # Do not change existing test cases.
+            # Add more columns if you need to.
+            # With all numbers and None, the column converts to float and
+            # the None here changes to NaN (which would break comparisons).
+            # After convert_to_str the NaN is back to a friendly None.
+            # Lists and dicts should recursively clean their internals but stay
+            # as native objects.
+            'a': [1.0, 2, 0.2, 0.0, None],
+            'b': ['1_1', ' ab ', 2, 2.56, None],
+            'c': [1, 2, 3, [1.0, ' 2', 'a'], {'a': 0.0, 'b': 2}]
         },
         dtype=object
     )
     df2 = pandas.read_json(df1.to_json(), dtype=object)
+
+    assert df1['a'][4] is None
+    assert df2['a'][4] is not None
+    assert numpy.isnan(df2['a'][4])
     assert not df1.astype(str).equals(df2.astype(str))
 
-    df1 = df1.applymap(
-        lambda x: numeric_to_str(x, replace_na=True)
-    )
-    df2 = df2.applymap(
-        lambda x: numeric_to_str(x, replace_na=True)
-    )
-    assert df1.astype(str).equals(df2.astype(str))
+    df3 = clean_up_df(df1)
+    df4 = clean_up_df(df2)
 
-    assert df1['b'][0] == '1_1'
-    assert df1['b'][1] == 'ab'
-    assert df1['b'][3] == '2.56'
-    assert df1['a'][0] == '1'
-    assert df1['a'][3] == '0'
-    assert df1['a'][4] == '0.2'
+    assert df3['a'][4] is None
+    assert df4['a'][4] is None
+    assert df3.astype(str).equals(df4.astype(str))
+
+    assert df3['b'][0] == '1_1'
+    assert df3['b'][1] == 'ab'
+    assert df3['b'][3] == '2.56'
+    assert df3['a'][0] == '1'
+    assert df3['a'][3] == '0'
+    assert df3['a'][2] == '0.2'
+    assert df3['c'][3] == "['1', '2', 'a']"
+    assert df3['c'][4] == "{'a': '0', 'b': '2'}"
+
+    # test that list and dict are subsequently recoverable
+    df5 = recover_containers_from_df_strings(df3)
+    assert df5['c'][3] == ['1', '2', 'a']
+    assert df5['c'][4] == {'a': '0', 'b': '2'}
+    # and that everything else is the same
+    for col in df5.columns:
+        for i in range(len(df5)):
+            if not (col == 'c' and ((i == 3) or (i == 4))):
+                assert df5[col][i] == df3[col][i]


### PR DESCRIPTION
Will recurse into lists and dicts to clean their contents for comparison across stages and then revert to their original native type.

closes #313 