### PR TITLE
🐛 Fix invalid use of pytest context managers

### DIFF
--- a/tests/data/simple_study/extract_configs/extract_config.py
+++ b/tests/data/simple_study/extract_configs/extract_config.py
@@ -40,9 +40,13 @@ operations = [
         in_col='sample',
         out_col=CONCEPT.BIOSPECIMEN.ID
     ),
-    keep_map(
+    value_map(
         in_col='analyte',
-        out_col=CONCEPT.BIOSPECIMEN.ANALYTE
+        out_col=CONCEPT.BIOSPECIMEN.ANALYTE,
+        m={
+            r'dna': constants.SEQUENCING.ANALYTE.DNA,
+            r'rna': constants.SEQUENCING.ANALYTE.RNA
+        }
     ),
     keep_map(
         in_col='diagnosis',

--- a/tests/test_app_settings.py
+++ b/tests/test_app_settings.py
@@ -163,7 +163,4 @@ def test_prod_app_mode(info_caplog, cleanup):
 
     # Ingest should fail since nothing set the required env vars
     with pytest.raises(SystemExit):
-        try:
-            pipeline.run()
-        except SystemExit as e:
-            raise e
+        pipeline.run()

--- a/tests/test_concept_graph.py
+++ b/tests/test_concept_graph.py
@@ -200,11 +200,11 @@ def test_to_from_dict():
     node_dict['somekey'] = 'foo'
     with pytest.raises(AttributeError) as e:
         ConceptNode.from_dict(node_dict)
-        assert 'concept_attribute_pair' in str(e)
+    assert 'somekey' in str(e.value)
 
     # Missing required key
     node_dict.pop('somekey')
     node_dict.pop('concept_attribute_pair')
     with pytest.raises(KeyError) as e:
         ConceptNode.from_dict(node_dict)
-        assert 'concept_attribute_pair' in str(e)
+    assert 'concept_attribute_pair' in str(e.value)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -22,11 +22,8 @@ def test_config_abs_cls():
     # Test that TypeError is raised if all abstract classes are not impl
     with pytest.raises(TypeError) as e:
         InvalidConfig()
-
-    abstract_methods = ['_read_file', '_validate']
-
-    for m in abstract_methods:
-        assert m in str(e)
+    for m in ['_read_file', '_validate']:
+        assert m in str(e.value)
 
     class Config(AbstractConfig):
         def _read_file(self, filepath):
@@ -46,12 +43,9 @@ def test_yaml_config():
     schema_path = os.path.join(TEST_DATA_DIR, 'yaml_schema.yml')
     config_path = os.path.join(TEST_DATA_DIR, 'invalid_yaml_config.yml')
 
-    with pytest.raises(ConfigValidationError):
-        try:
-            YamlConfig(config_path, schema_path=schema_path)
-        except ConfigValidationError as e:
-            assert config_path in str(e)
-            raise
+    with pytest.raises(ConfigValidationError) as e:
+        YamlConfig(config_path, schema_path=schema_path)
+    assert config_path in str(e.value)
 
     config_path = os.path.join(TEST_DATA_DIR, 'valid_yaml_config.yml')
     YamlConfig(config_path, schema_path=schema_path)

--- a/tests/test_extract_operations.py
+++ b/tests/test_extract_operations.py
@@ -71,7 +71,7 @@ def test_df_map():
     func = operations.df_map(lambda df: None)
     with pytest.raises(TypeError) as e:
         func(df)
-        assert 'DataFrame' in str(e)
+    assert 'DataFrame' in str(e.value)
 
 
 def test_keep_map():

--- a/tests/test_extract_stage.py
+++ b/tests/test_extract_stage.py
@@ -107,34 +107,25 @@ def test_bad_file_types(**kwargs):
     url = f'http://localhost:1234/{filename}/download'
     with open(TEST_FILE_PATH, "rb") as tf:
         mock.get(url, content=tf.read(), status_code=200)
-    with pytest.raises(ConfigValidationError):
-        try:
-            es._source_file_to_df(url)
-        except ConfigValidationError as e:
-            assert "Could not determine appropriate loader" in str(e)
-            raise
+    with pytest.raises(ConfigValidationError) as e:
+        es._source_file_to_df(url)
+    assert "Could not determine appropriate loader" in str(e.value)
 
     # unknown type
-    with pytest.raises(ConfigValidationError):
-        try:
-            es._source_file_to_df(
-                'file://' +
-                os.path.join(TEST_DATA_DIR, 'yaml_schema.yml')
-            )
-        except ConfigValidationError as e:
-            assert "Could not determine appropriate loader" in str(e)
-            raise
+    with pytest.raises(ConfigValidationError) as e:
+        es._source_file_to_df(
+            'file://' +
+            os.path.join(TEST_DATA_DIR, 'yaml_schema.yml')
+        )
+    assert "Could not determine appropriate loader" in str(e.value)
 
     # good type but error in load function
-    with pytest.raises(ConfigValidationError):
-        try:
-            es._source_file_to_df(
-                'file://' +
-                os.path.join(TEST_DATA_DIR, 'concept_graph.json')
-            )
-        except ConfigValidationError as e:
-            assert "Could not determine appropriate loader" not in str(e)
-            raise
+    with pytest.raises(ConfigValidationError) as e:
+        es._source_file_to_df(
+            'file://' +
+            os.path.join(TEST_DATA_DIR, 'concept_graph.json')
+        )
+    assert "Could not determine appropriate loader" not in str(e.value)
 
 
 def test_no_load_return():

--- a/tests/test_file_retriever.py
+++ b/tests/test_file_retriever.py
@@ -267,10 +267,7 @@ def test_validate_auth_configs(auth_config, expected_exc):
     fr = FileRetriever(cleanup_at_exit=True)
     if expected_exc:
         with pytest.raises(expected_exc) as e:
-            try:
-                fr._validate_auth_config(auth_config)
-            except expected_exc as e:
-                raise e
+            fr._validate_auth_config(auth_config)
     else:
         fr._validate_auth_config(auth_config)
 
@@ -298,12 +295,9 @@ def test_invalid_urls(url):
     Test bad url
     """
     with pytest.raises(LookupError) as e:
-        try:
-            FileRetriever().get(url)
-        except LookupError as e:
-            assert f"In URL: {url}" in str(e)
-            assert "Invalid protocol:" in str(e)
-            raise
+        FileRetriever().get(url)
+    assert f"In URL: {url}" in str(e.value)
+    assert "Invalid protocol:" in str(e.value)
 
 
 def _test_get_file(url, storage_dir, use_storage_dir, cleanup_at_exit,

--- a/tests/test_guided_transform.py
+++ b/tests/test_guided_transform.py
@@ -140,7 +140,7 @@ def test_no_transform_module(target_api_config):
     """
     with pytest.raises(ConfigValidationError) as e:
         GuidedTransformStage(None)
-        assert 'Guided transformation requires a' in str(e)
+    assert 'Guided transformation requires a' in str(e.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ingest_stage.py
+++ b/tests/test_ingest_stage.py
@@ -45,14 +45,10 @@ def test_ingest_stage_abs_cls():
     # Test that TypeError is raised if all abstract classes are not impl
     with pytest.raises(TypeError) as e:
         InvalidIngestStage()
-
-    abstract_methods = ['_run',
-                        '_write_output',
-                        '_read_output',
-                        '_validate_run_parameters']
-
-    for m in abstract_methods:
-        assert m in str(e)
+    for m in [
+        '_run', '_write_output', '_read_output', '_validate_run_parameters'
+    ]:
+        assert m in str(e.value)
 
 
 def test_invalid_run_parameters():
@@ -75,7 +71,7 @@ def test_invalid_run_parameters():
             pass
 
     stage = ValidIngestStage()
-    with pytest.raises(InvalidIngestStageParameters) as e:
+    with pytest.raises(InvalidIngestStageParameters):
         stage.run(False)
 
     # No exception should be raised on valid params
@@ -105,7 +101,7 @@ def test_stage_read_write(ValidIngestStage):
     stage.run('hello world')
     with pytest.raises(FileNotFoundError) as e:
         stage.read_output()
-        assert 'output directory does not exist' in str(e)
+    assert 'The output directory: "None" does not exist' in str(e.value)
 
     # Test output is written and read when stage_cache_dir is defined
     stage = ValidIngestStage(ingest_output_dir=TEST_INGEST_OUTPUT_DIR)

--- a/tests/test_standard_model.py
+++ b/tests/test_standard_model.py
@@ -308,7 +308,7 @@ def test_find_non_existent(target_api_config, model):
     # Test find concept attribute value
     with pytest.raises(ValueError) as e:
         g.find_attribute_value(start_node, concept_attr, rg)
-        assert start_node.key in e
+    assert start_node.key in str(e.value)
 
 
 def test_general_find(target_api_config, random_data_df_dict):

--- a/tests/test_target_api_config.py
+++ b/tests/test_target_api_config.py
@@ -44,12 +44,12 @@ def test_missing_req_attrs(kids_first_config, test_attr):
 
     with pytest.raises(AttributeError) as e:
         kids_first_config._validate_required_attrs()
-        assert 'Missing one of the required keys' in str(e)
+    assert 'Missing one of the required keys' in str(e.value)
 
 
 @pytest.mark.parametrize('test_attr,test_value',
-                         [('target_concepts', 'foo'),
-                          ('relationships', 'foo'),
+                         [('target_concepts', '_asdfasdfasdfasdf_'),
+                          ('relationships', '_asdfasdfasdfasdf_'),
                           ('target_service_entity_id', {})
                           ])
 def test_req_attr_wrong_type(kids_first_config, test_attr, test_value):
@@ -81,8 +81,8 @@ def test_missing_req_target_concept_keys(kids_first_config, test_key):
     # Test
     with pytest.raises(KeyError) as e:
         kids_first_config._validate_required_keys()
-        assert test_key in str(e)
-        assert 'Missing one of target concept dict required keys' in str(e)
+    assert test_key in str(e.value)
+    assert 'missing one of target concept dict required keys' in str(e.value)
 
 
 def test_mapped_standard_concepts(kids_first_config):
@@ -95,14 +95,13 @@ def test_mapped_standard_concepts(kids_first_config):
     target_concept = random.choice(list(target_concepts.keys()))
 
     # Invalid mapping
-    mapped_value = 'foo'
+    mapped_value = '_asdfasdfasdfasdf_'
     target_concepts[target_concept]['standard_concept'] = mapped_value
 
     # Test
     with pytest.raises(ValueError) as e:
         kids_first_config._validate_mapped_standard_concepts()
-        assert target_concept in str(e)
-        assert f'The mapped standard concept: {mapped_value}' in str(e)
+    assert f'The mapped standard concept: {mapped_value}' in str(e.value)
 
 
 def test_target_concept_attr(kids_first_config):
@@ -117,14 +116,14 @@ def test_target_concept_attr(kids_first_config):
     attr = random.choice(list(properties.keys()))
 
     # Invalid mapping
-    mapped_value = 'foo'
+    mapped_value = '_asdfasdfasdfasdf_'
     properties[attr] = mapped_value
 
     # Test
     with pytest.raises(ValueError) as e:
         kids_first_config._validate_target_concept_attr_mappings()
-        assert mapped_value in str(e)
-        assert f'{target_concept}.{attr}' in str(e)
+    assert mapped_value in str(e.value)
+    assert f'{target_concept}.{attr}' in str(e.value)
 
 
 @pytest.mark.parametrize(
@@ -173,7 +172,7 @@ def test_links(kids_first_config, link_list, expected_exc, expected_msg):
     if expected_exc:
         with pytest.raises(expected_exc) as e:
             kids_first_config._validate_target_concept_attr_mappings()
-        assert expected_msg in str(e)
+        assert expected_msg in str(e.value)
     else:
         kids_first_config._validate_target_concept_attr_mappings()
 
@@ -193,7 +192,7 @@ def test_mapped_target_concept_attr(kids_first_config):
     # Test
     with pytest.raises(TypeError) as e:
         kids_first_config._validate_target_concept_attr_mappings()
-        assert 'All target concept attributes must be strings' in str(e)
+    assert 'requires all items in props_dict.keys() to be' in str(e.value)
 
 
 def test_endpoints(kids_first_config):
@@ -210,7 +209,7 @@ def test_endpoints(kids_first_config):
     # Test
     with pytest.raises(TypeError) as e:
         kids_first_config._validate_endpoints()
-        assert 'All values in "endpoints" dict must be strings' in str(e)
+    assert 'requires all items in endpoints to be' in str(e.value)
 
 
 def test_relationships_types_and_values(kids_first_config):
@@ -226,25 +225,28 @@ def test_relationships_types_and_values(kids_first_config):
     relationships[parent_concept] = 'bar'
     with pytest.raises(TypeError) as e:
         kids_first_config._validate_relationships()
-        assert 'All values in relationships dict must be sets.' in str(e)
+    assert (
+        'requires all items in relationships.values() to be'
+    ) in str(e.value)
     # Reset
     relationships[parent_concept] = _saved
 
     # Test non-standard_concept key
-    relationships['foo'] = {'bar'}
+    relationships['_asdfasdfasdfasdf_'] = {'bar'}
     with pytest.raises(ValueError) as e:
         kids_first_config._validate_relationships()
-        assert ('Keys in relationships dict must be '
-                'one of the standard concepts') in str(e)
+    assert (
+        'Keys in relationships dict must be one of the standard concepts'
+    ) in str(e.value)
     # Remove invalid key
-    relationships.pop('foo')
+    relationships.pop('_asdfasdfasdfasdf_')
 
     # Test non-standard_concept set member
     relationships[parent_concept] = {'baz'}
     with pytest.raises(ValueError) as e:
         kids_first_config._validate_relationships()
-        assert ('Set values in relationships dict must be one of the standard '
-                'concepts.') in str(e)
+    assert ('Set values in relationships dict must be one of the standard '
+            'concepts.') in str(e.value)
 
 
 def test_relationships_dag(kids_first_config):
@@ -260,4 +262,4 @@ def test_relationships_dag(kids_first_config):
 
     with pytest.raises(ValueError) as e:
         kids_first_config._validate_relationships()
-        assert 'MUST be a directed acyclic graph' in str(e)
+    assert 'MUST be a directed acyclic graph' in str(e.value)

--- a/tests/test_transform_stage.py
+++ b/tests/test_transform_stage.py
@@ -200,7 +200,7 @@ def test_no_key_comp_defined(guided_transform_stage):
     del unique_key_composition[CONCEPT.PARTICIPANT._CONCEPT_NAME]
     with pytest.raises(AssertionError) as e:
         guided_transform_stage._add_unique_key_cols(df, unique_key_composition)
-        assert 'key composition not defined' in str(e)
+    assert 'key composition not defined' in str(e.value)
     unique_key_composition[CONCEPT.PARTICIPANT._CONCEPT_NAME] = save
 
 

--- a/tests/test_type_safety.py
+++ b/tests/test_type_safety.py
@@ -58,12 +58,9 @@ type_exemplars = [
 
 def test_silly_user():
     assert_safe_type(5, int)  # Why are they asking?!
-    with pytest.raises(TypeError):
-        try:
-            assert_safe_type(5, float)  # Why are they asking?!
-        except TypeError as e:
-            assert __UNNAMED_OBJECT in str(e)
-            raise
+    with pytest.raises(TypeError) as e:
+        assert_safe_type(5, float)  # Why are they asking?!
+    assert __UNNAMED_OBJECT in str(e.value)
 
 
 # Special care is needed for the tests to cover the fact that functions are
@@ -131,19 +128,13 @@ def test_name_in_error_message():
     """
     pickle = 5
     pockle = 5
-    with pytest.raises(TypeError):
-        try:
-            assert_safe_type(pickle, bool)
-        except TypeError as e:
-            assert 'pickle' in str(e)
-            raise
+    with pytest.raises(TypeError) as e:
+        assert_safe_type(pickle, bool)
+    assert 'pickle' in str(e.value)
 
-    with pytest.raises(TypeError):
-        try:
-            assert_safe_type(pockle, bool)
-        except TypeError as e:
-            assert 'pockle' in str(e)
-            raise
+    with pytest.raises(TypeError) as e:
+        assert_safe_type(pockle, bool)
+    assert 'pockle' in str(e.value)
 
 
 def test_attribute_type_checking():
@@ -157,36 +148,26 @@ def test_attribute_type_checking():
 
         def test_self(self):
             assert_safe_type(self.bar.baz, int)
-            with pytest.raises(TypeError):
-                try:
-                    assert_safe_type(self.bar.baz, str)
-                except TypeError as e:
-                    assert 'self.bar.baz' in str(e)
-                    raise
+            with pytest.raises(TypeError) as e:
+                assert_safe_type(self.bar.baz, str)
+            assert 'self.bar.baz' in str(e.value)
 
     assert_safe_type(foo.bar.baz, int)
     assert_safe_type(foo.qux, str)
     assert_safe_type(foo.bar, object)
     foo().test_self()
 
-    with pytest.raises(TypeError):
-        try:
-            assert_safe_type(foo.bar, str)
-        except TypeError as e:
-            assert 'foo.bar' in str(e)
-            raise
-    with pytest.raises(TypeError):
-        try:
-            assert_safe_type(foo.bar.baz, str)
-        except TypeError as e:
-            assert 'foo.bar.baz' in str(e)
-            raise
-    with pytest.raises(TypeError):
-        try:
-            assert_safe_type(foo.qux, int)
-        except TypeError as e:
-            assert 'foo.qux' in str(e)
-            raise
+    with pytest.raises(TypeError) as e:
+        assert_safe_type(foo.bar, str)
+    assert 'foo.bar' in str(e.value)
+
+    with pytest.raises(TypeError) as e:
+        assert_safe_type(foo.bar.baz, str)
+    assert 'foo.bar.baz' in str(e.value)
+
+    with pytest.raises(TypeError) as e:
+        assert_safe_type(foo.qux, int)
+    assert 'foo.qux' in str(e.value)
 
 
 def test_direct_list_values():
@@ -201,29 +182,22 @@ def test_direct_list_values():
         [1, 2.0, 3.0, 4.0],
         [1.0, 2.0, 3.0, 4]
     ]:
-        with pytest.raises(TypeError):
-            try:
-                assert_all_safe_type(my_list, float)
-            except TypeError as e:
-                assert __ALL_SIGNIFIER in str(e)
-                assert __UNNAMED_OBJECT not in str(e)
-                raise
+        with pytest.raises(TypeError) as e:
+            assert_all_safe_type(my_list, float)
+        assert __ALL_SIGNIFIER in str(e.value)
+        assert __UNNAMED_OBJECT not in str(e.value)
+
     assert_all_safe_type([1.0, 2.0, 3.0, 4.0], float)
-    with pytest.raises(TypeError):
-        try:
-            assert_all_safe_type([1.0, 2.0, 3.0, 4.0], int)
-        except TypeError as e:
-            assert __ALL_SIGNIFIER in str(e)
-            assert __UNNAMED_OBJECT in str(e)
-            raise
+    with pytest.raises(TypeError) as e:
+        assert_all_safe_type([1.0, 2.0, 3.0, 4.0], int)
+    assert __ALL_SIGNIFIER in str(e.value)
+    assert __UNNAMED_OBJECT in str(e.value)
+
     assert_all_safe_type({'a': 1, 'b': 2, 'c': 3}, str)
-    with pytest.raises(TypeError):
-        try:
-            assert_all_safe_type({'a': 1, 'b': 2, 'c': 3}, int)
-        except TypeError as e:
-            assert __ALL_SIGNIFIER in str(e)
-            assert __UNNAMED_OBJECT in str(e)
-            raise
+    with pytest.raises(TypeError) as e:
+        assert_all_safe_type({'a': 1, 'b': 2, 'c': 3}, int)
+    assert __ALL_SIGNIFIER in str(e.value)
+    assert __UNNAMED_OBJECT in str(e.value)
 
 
 class test_obj:
@@ -239,12 +213,9 @@ def test_call_values():
     Test pulling values indirectly from function calls
     """
     assert_safe_type(test_obj(1).foo(arg=5), int)
-    with pytest.raises(TypeError):
-        try:
-            assert_safe_type(test_obj(1).foo(arg=5), float)
-        except TypeError as e:
-            assert 'test_obj(1).foo(arg=5)' in str(e)
-            raise
+    with pytest.raises(TypeError) as e:
+        assert_safe_type(test_obj(1).foo(arg=5), float)
+    assert 'test_obj(1).foo(arg=5)' in str(e.value)
 
 
 def test_call_list_values():
@@ -255,37 +226,26 @@ def test_call_list_values():
     my_dict = {'a': 1, 'b': 2, 'c': 3}
     assert_all_safe_type(my_dict.keys(), str)
     assert_all_safe_type(my_dict.values(), int)
-    with pytest.raises(TypeError):
-        try:
-            assert_all_safe_type(my_dict.values(), float)
-        except TypeError as e:
-            assert __ALL_SIGNIFIER in str(e)
-            assert 'my_dict.values()' in str(e)
-            raise
-    with pytest.raises(TypeError):
-        try:
-            assert_all_safe_type(my_dict.keys(), bool)
-        except TypeError as e:
-            assert __ALL_SIGNIFIER in str(e)
-            assert 'my_dict.keys()' in str(e)
-            raise
+    with pytest.raises(TypeError) as e:
+        assert_all_safe_type(my_dict.values(), float)
+    assert __ALL_SIGNIFIER in str(e.value)
+    assert 'my_dict.values()' in str(e.value)
+
+    with pytest.raises(TypeError) as e:
+        assert_all_safe_type(my_dict.keys(), bool)
+    assert __ALL_SIGNIFIER in str(e.value)
+    assert 'my_dict.keys()' in str(e.value)
 
 
 # test checking outside of a function (yes this matters)
 foo = 5
 assert_safe_type(foo, int)
-with pytest.raises(TypeError):
-    try:
-        assert_safe_type(foo, float)
-    except TypeError as e:
-        assert 'foo' in str(e)
-        raise
+with pytest.raises(TypeError) as e:
+    assert_safe_type(foo, float)
+assert 'foo' in str(e.value)
 
 assert_all_safe_type([1.0, 2.0, 3.0, 4.0], float)
-with pytest.raises(TypeError):
-    try:
-        assert_all_safe_type([1.0, 2.0, 3.0, 4.0], int)
-    except TypeError as e:
-        assert __ALL_SIGNIFIER in str(e)
-        assert __UNNAMED_OBJECT in str(e)
-        raise
+with pytest.raises(TypeError) as e:
+    assert_all_safe_type([1.0, 2.0, 3.0, 4.0], int)
+assert __ALL_SIGNIFIER in str(e.value)
+assert __UNNAMED_OBJECT in str(e.value)


### PR DESCRIPTION
When using pytest.raises as a context manager, normal context manager
rules apply, and the exception raised must be the final line in the
scope of the context manager. Lines of code after that within the scope
of the context manager will not be executed.

A few valid but verbose uses were also changed for consistency.

closes #300 