### PR TITLE
✨ Optional multithreaded loading

### DIFF
--- a/kf_lib_data_ingest/app/cli.py
+++ b/kf_lib_data_ingest/app/cli.py
@@ -28,6 +28,7 @@ def common_args_options(func):
                           type=click.Path(exists=True,
                                           file_okay=True,
                                           dir_okay=True))(func)
+
     # App settings
     func = click.option(
         '--app_settings', 'app_settings_filepath',
@@ -51,11 +52,13 @@ def common_args_options(func):
                              for level_name in logging._nameToLevel.keys()]
                         ),
                         help=log_help_txt)(func)
+
     # Target URL
     func = click.option(
         '-t', '--target_url',
               default=DEFAULT_TARGET_URL, show_default=True,
               help='Target service URL where data will be loaded into')(func)
+
     # Stages
     func = click.option(
         '--stages', 'stages_to_run_str',
@@ -68,6 +71,38 @@ def common_args_options(func):
             'execution set by the pipeline and contain no gaps in the '
             'stage sequence.'
         ))(func)
+
+    # Resume loading from
+    func = click.option(
+        '--resume_from',
+        default=None,
+        help=(
+            'Dry run until a given target ID, and then load starting '
+            'there.'
+        )
+    )(func)
+
+    # Multithreaded loading
+    func = click.option(
+        '--use_async',
+        default=False,
+        is_flag=True,
+        help=(
+            'A flag specifying whether to use sync or async loading '
+            'into the target service'
+        )
+    )(func)
+
+    # ** Temporary - until auto transform is further developed **
+    # func = click.option(
+    #     '--auto_transform',
+    #     default=False,
+    #     is_flag=True,
+    #     help=(
+    #         'A flag specifying whether to use auto transformation or '
+    #         'user guided transformation'
+    #     )
+    # )(func)
     return func
 
 
@@ -88,21 +123,6 @@ def cli():
               is_flag=True,
               help='A flag specifying whether to only pretend to send data to '
               'the target service. Overrides the resume_from setting.')
-@click.option('--resume_from',
-              default=None,
-              help='Dry run until a given target ID, and then load starting '
-              'there.')
-@click.option('--use_async',
-              default=False,
-              is_flag=True,
-              help='A flag specifying whether to use sync or async loading '
-              'into the target service')
-# ** Temporary - until auto transform is further developed **
-# @click.option('--auto_transform',
-#               default=False,
-#               is_flag=True,
-#               help='A flag specifying whether to use auto transformation or '
-#               'user guided transformation')
 @common_args_options
 def ingest(ingest_package_config_path, app_settings_filepath, log_level_name,
            target_url, stages_to_run_str, use_async, dry_run, resume_from):
@@ -153,8 +173,10 @@ def ingest(ingest_package_config_path, app_settings_filepath, log_level_name,
 @cli.command()
 @common_args_options
 @click.pass_context
-def test(ctx, ingest_package_config_path, app_settings_filepath,
-         log_level_name, target_url, stages_to_run_str):
+def test(
+    ctx, ingest_package_config_path, app_settings_filepath, log_level_name,
+    target_url, stages_to_run_str, use_async, resume_from
+):
     """
     Run the Kids First data ingest pipeline in dry_run mode (--dry_run=True)
     Used for testing ingest packages.

--- a/kf_lib_data_ingest/etl/configuration/log.py
+++ b/kf_lib_data_ingest/etl/configuration/log.py
@@ -25,7 +25,10 @@ class NoTokenFormatter(logging.Formatter):
         return s
 
 
-DEFAULT_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+DEFAULT_FORMAT = (
+    '%(asctime)s - %(name)s'
+    ' - Thread: %(threadName)s - %(levelname)s - %(message)s'
+)
 DEFAULT_FORMATTER = NoTokenFormatter(DEFAULT_FORMAT)
 
 

--- a/kf_lib_data_ingest/etl/load/load.py
+++ b/kf_lib_data_ingest/etl/load/load.py
@@ -1,10 +1,12 @@
 """
 Module for loading the transform output into the dataservice.
 """
+import concurrent.futures
 import logging
 import os
 from collections import defaultdict
 from pprint import pformat
+from threading import Lock
 from urllib.parse import urlparse
 
 import pandas
@@ -12,20 +14,22 @@ import requests
 from requests import RequestException
 from sqlite3worker import Sqlite3Worker, sqlite3worker
 
+from kf_lib_data_ingest.common import constants
 from kf_lib_data_ingest.common.errors import InvalidIngestStageParameters
 from kf_lib_data_ingest.common.misc import multisplit, str_to_obj
 from kf_lib_data_ingest.common.stage import IngestStage
-from kf_lib_data_ingest.network.utils import requests_retry_session
-from kf_lib_data_ingest.config import DEFAULT_ID_CACHE_FILENAME
-from kf_lib_data_ingest.etl.configuration.target_api_config import (
-    TargetAPIConfig
-)
 from kf_lib_data_ingest.common.type_safety import (
     assert_all_safe_type,
     assert_safe_type
 )
-from kf_lib_data_ingest.common import constants
+from kf_lib_data_ingest.config import DEFAULT_ID_CACHE_FILENAME
+from kf_lib_data_ingest.etl.configuration.target_api_config import (
+    TargetAPIConfig
+)
+from kf_lib_data_ingest.network.utils import requests_retry_session
+
 sqlite3worker.LOGGER.setLevel(logging.WARNING)
+count_lock = Lock()
 
 
 def send(req):
@@ -73,6 +77,8 @@ class LoadStage(IngestStage):
         self.dry_run = dry_run
         self.resume_from = resume_from
         self.study_id = study_id
+        self.totals = {}
+        self.counts = {}
 
         target = urlparse(target_url).netloc or urlparse(target_url).path
         self.uid_cache_filepath = os.path.join(
@@ -370,11 +376,10 @@ class LoadStage(IngestStage):
                 id_str = f' {{{self.target_id_key}: {tgt_id}}}'
             else:
                 req_method = 'POST'
-                id_str = ''
+                id_str = f' ({entity_id})'
 
-            self.logger.info(f'DRY RUN - {req_method} {endpoint}{id_str}')
             self.logger.debug(f'Request body preview:\n{pformat(body)}')
-
+            log_msg = f'DRY RUN - {req_method} {endpoint}{id_str}'
         else:
             # send to the target service
             entity = self._submit(entity_id, entity_type, endpoint, body)
@@ -383,10 +388,18 @@ class LoadStage(IngestStage):
             tgt_id = entity[self.target_id_key]
             self._store_target_id(entity_type, entity_id, tgt_id)
 
-            # log action
-            self.logger.info(
+            log_msg = (
                 f'Loaded {entity_type} {entity_id} --> {{'
                 f'{self.target_id_key}: {tgt_id}}}'
+            )
+
+        # log action
+        with count_lock:
+            self.counts[entity_type] += 1
+            self.logger.info(
+                log_msg +
+                f' (#{self.counts[entity_type]} '
+                f'of {self.totals[entity_type]})'
             )
 
     def _validate_run_parameters(self, target_entities):
@@ -455,19 +468,30 @@ class LoadStage(IngestStage):
             self.logger.info(f'Begin loading {entity_type}')
 
             self.prev_entity = None
-            total = len(entities)
-            for i, entity in enumerate(entities):
+            self.totals[entity_type] = len(entities)
+            self.counts[entity_type] = 0
+
+            if self.use_async:
+                ex = concurrent.futures.ThreadPoolExecutor()
+
+            for entity in entities:
                 entity_id = entity['id']
                 endpoint = entity['endpoint']
                 body = entity['properties']
                 links = entity['links']
 
-                self.logger.info(
-                    f'Loading {entity_type} {entity_id} (#{i+1} of {total})'
-                )
-                self._load_entity(
-                    entity_type, endpoint, entity_id, body, links
-                )
+                if self.use_async and not self.resume_from:
+                    ex.submit(
+                        self._load_entity,
+                        entity_type, endpoint, entity_id, body, links
+                    )
+                else:
+                    self._load_entity(
+                        entity_type, endpoint, entity_id, body, links
+                    )
+
+            if self.use_async:
+                ex.shutdown()
 
             self.logger.info(f'End loading {entity_type}')
 


### PR DESCRIPTION
All entities within a group are thrown into a background worker pool unless the resume target hasn't been found yet.

This does not cross entity type group boundaries. That would require
significant enough extra complexity to ensure proper foreign key load
ordering that I don't think the minimal extra gain would be worth it.

Changes in cli.py are just to add the existing keywords to `kidsfirst test` as well.

closes #34 