### PR TITLE
👷 Blanket ignore all dotfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# MacOS stuff
-.DS_Store
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -10,13 +7,11 @@ __pycache__/
 *.so
 
 # Distribution / packaging
-.Python
 build/
 develop-eggs/
 dist/
 downloads/
 eggs/
-.eggs/
 lib/
 lib64/
 parts/
@@ -24,7 +19,6 @@ sdist/
 var/
 wheels/
 *.egg-info/
-.installed.cfg
 *.egg
 MANIFEST
 
@@ -40,15 +34,9 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
-.tox/
-.coverage
-.coverage.*
-.cache
 nosetests.xml
 coverage.xml
 *.cover
-.hypothesis/
-.pytest_cache/
 
 # Translations
 *.mo
@@ -61,22 +49,12 @@ db.sqlite3
 
 # Flask stuff:
 instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
 
 # Sphinx documentation
 docs/_build/
 
 # PyBuilder
 target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# pyenv
-.python-version
 
 # celery beat schedule file
 celerybeat-schedule
@@ -85,29 +63,14 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
-.env
-.venv
 env/
 venv/
 ENV/
 env.bak/
 venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
 # mkdocs documentation
 /site
-
-# mypy
-.mypy_cache/
-
-# VS Code
-.vscode/
 
 # stage serialization output
 output/
@@ -116,4 +79,7 @@ output/
 cached_schema.json
 
 test_graph.gml
+
+# dot files and folders
+.*
 


### PR DESCRIPTION
This PR updates `.gitignore` as ignoring dot files and folders. This is same as kids-first/kf-ingest-packages#57.