### PR TITLE
✨ FileRetriever static auth configs

### DIFF
--- a/kf_lib_data_ingest/common/file_retriever.py
+++ b/kf_lib_data_ingest/common/file_retriever.py
@@ -222,6 +222,7 @@ class FileRetriever(object):
         "https": _web_save,
         "file": _file_save
     }
+    static_auth_configs = None
 
     def __init__(self, storage_dir=None, cleanup_at_exit=True,
                  auth_configs=None):
@@ -271,10 +272,10 @@ class FileRetriever(object):
                                                         dir=".")
             self.storage_dir = self.__tmpdir.name
         self._files = {}
-        self.auth_configs = auth_configs
+        self.auth_configs = auth_configs or FileRetriever.static_auth_configs
 
         if self.auth_configs:
-            assert_safe_type(auth_configs, dict)
+            assert_safe_type(self.auth_configs, dict)
 
     def get(self, url, auth_config=None):
         """

--- a/kf_lib_data_ingest/common/misc.py
+++ b/kf_lib_data_ingest/common/misc.py
@@ -45,7 +45,6 @@ def import_module_from_file(filepath):
     spec = importlib.util.spec_from_file_location(module_name, filepath)
     imported_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(imported_module)
-
     return imported_module
 
 

--- a/kf_lib_data_ingest/etl/extract/extract.py
+++ b/kf_lib_data_ingest/etl/extract/extract.py
@@ -60,6 +60,12 @@ class ExtractStage(IngestStage):
         super().__init__(stage_cache_dir)
 
         assert_safe_type(extract_config_dir, str)
+
+        # must set FileRetriever.static_auth_configs before extract configs are
+        # loaded
+        FileRetriever.static_auth_configs = auth_configs
+        self.FR = FileRetriever()
+
         self.extract_config_dir = extract_config_dir
         self.extract_configs = [
             ExtractConfig(filepath)
@@ -71,8 +77,6 @@ class ExtractStage(IngestStage):
                 ec.config_filepath,
                 start=self.extract_config_dir
             )
-
-        self.FR = FileRetriever(auth_configs=auth_configs)
 
     def _output_path(self):
         """

--- a/tests/test_file_retriever.py
+++ b/tests/test_file_retriever.py
@@ -1,4 +1,5 @@
 import base64
+import importlib
 import logging
 import os
 from urllib.parse import quote, urlencode, urljoin
@@ -338,3 +339,24 @@ def _assert_file(storage_dir, file_path):
     ]) == storage_dir
 
     assert os.path.isfile(file_path)
+
+
+def test_static_auth_configs():
+    FileRetriever.static_auth_configs = {'test': 'test'}
+
+    # test persists locally
+    fr = FileRetriever()
+    assert fr.static_auth_configs == {'test': 'test'}
+
+    # test persists across modules
+    test_spec = importlib.util.spec_from_loader('test_module', loader=None)
+    test_module = importlib.util.module_from_spec(test_spec)
+    test_code = (
+        'def test_static_auth_configs():\n'
+        ' from kf_lib_data_ingest.common.file_retriever import FileRetriever\n'
+        ' fr = FileRetriever()\n'
+        ' assert fr.static_auth_configs == {"test": "test"}\n'
+    )
+    exec(test_code, test_module.__dict__)
+    test_module.test_static_auth_configs()
+    fr.static_auth_configs = None


### PR DESCRIPTION
If FileRetriever is initialized without an auth_configs argument, it now
looks to see if someone set a static one. This lets extract config
modules use the auth_configs structure, which is an application level
setting.

closes #373