### PR TITLE
🐛 Update entity relationship external_id on mismatch

### DIFF
--- a/kf_lib_data_ingest/etl/load/load.py
+++ b/kf_lib_data_ingest/etl/load/load.py
@@ -281,9 +281,13 @@ class LoadStage(IngestStage):
             # Our dataservice returns 400 if a relationship already exists
             # even though that's a silly thing to do.
             # See https://github.com/kids-first/kf-api-dataservice/issues/419
+            extid = body.pop("external_id", None)
             resp = self._GET(endpoint, body)
             result = resp.json()['results'][0]
             self.logger.debug(f'Already exists:\n{pformat(result)}')
+            if extid != result["external_id"]:
+                self.logger.debug(f"Patching with new external_id: {extid}")
+                self._PATCH(endpoint, result["kf_id"], {"external_id": extid})
             return result
         else:
             self.logger.debug(f'Response error:\n{pformat(resp.__dict__)}')

--- a/kf_lib_data_ingest/etl/load/load.py
+++ b/kf_lib_data_ingest/etl/load/load.py
@@ -227,7 +227,7 @@ class LoadStage(IngestStage):
         host = self.target_url
         return RetrySession().get(
             url='/'.join([v.strip('/') for v in [host, endpoint]]),
-            params=body
+            params={k: v for k, v in body.items() if v is not None}
         )
 
     def _submit(self, entity_id, entity_type, endpoint, body):


### PR DESCRIPTION
Make sure that an existing entity relationship (e.g. a BSDG) gets updated with the external ID that we want.

closes #386