### PR TITLE
🐛 Update external_id mismatch on existing link

### DIFF
--- a/kf_lib_data_ingest/etl/load/load.py
+++ b/kf_lib_data_ingest/etl/load/load.py
@@ -281,9 +281,13 @@ class LoadStage(IngestStage):
             # Our dataservice returns 400 if a relationship already exists
             # even though that's a silly thing to do.
             # See https://github.com/kids-first/kf-api-dataservice/issues/419
+            extid = body.pop("external_id", None)
             resp = self._GET(endpoint, body)
             result = resp.json()['results'][0]
             self.logger.debug(f'Already exists:\n{pformat(result)}')
+            if extid != result["external_id"]:
+                self.logger.debug(f"Patching with new external_id: {extid}")
+                self._PATCH(endpoint, result["kf_id"], {"external_id": extid})
             return result
         else:
             self.logger.debug(f'Response error:\n{pformat(resp.__dict__)}')


### PR DESCRIPTION
Catch a special case where an existing entity relationship has a
different external ID than what we want it to have.

closes #386