### PR TITLE
🔇 Only show comparison mismatches

### DIFF
--- a/kf_lib_data_ingest/etl/stage_analyses.py
+++ b/kf_lib_data_ingest/etl/stage_analyses.py
@@ -152,12 +152,11 @@ def _compare(name_one, list_one, name_two, list_two):
         indicator=indicator,
     )
     comparison_df = comparison_df.astype(object).fillna("")
-    diff_num = comparison_df[comparison_df[indicator] != "both"].shape[0]
-
-    comparison_df[indicator].replace(
-        {"left_only": NO, "right_only": NO, "both": YES}, inplace=True
-    )
-
+    comparison_df = comparison_df[comparison_df[indicator] != "both"][
+        [name_one, name_two]
+    ]
+    diff_num = comparison_df.shape[0]
+    comparison_df.columns = "In " + comparison_df.columns
     return comparison_df, diff_num
 
 


### PR DESCRIPTION
closes #392 


Consider that this would otherwise show all 15654 lines in the table because just 2 are missing:
```

ExtractStage
============

UNIQUE COUNTS:
{'GENOMIC_FILE|FILE_NAME': 15654}

⚠️ No expected counts registered.

TransformStage
==============

UNIQUE COUNTS:
{'GENOMIC_FILE|FILE_NAME': 15652}

⚠️ No expected counts registered.

COMPARING COUNTS
================

❌ Column values for GENOMIC_FILE|FILE_NAME not equal between ExtractStage and TransformStage
Number of different values = 2

+--------------------------------------------------------------------------+---------------------+
| In ExtractStage                                                          | In TransformStage   |
|--------------------------------------------------------------------------+---------------------|
| cdc492f5-3a11-40df-9995-d99a3c65313f.mutect2_somatic.PASS.vep.vcf.gz     |                     |
| cdc492f5-3a11-40df-9995-d99a3c65313f.mutect2_somatic.PASS.vep.vcf.gz.tbi |                     |
+--------------------------------------------------------------------------+---------------------+

```