### PR TITLE
✅ Keep FileRetriever().get() safe

### DIFF
--- a/kf_lib_data_ingest/network/oauth2.py
+++ b/kf_lib_data_ingest/network/oauth2.py
@@ -54,7 +54,7 @@ def get_service_token(provider_domain, audience, client_id, client_secret):
     if response.status_code != 200:
         logger.error(
             f"Could not fetch access token from {oauth_token_url}! "
-            f"Caused by {response.text}, status_code: {response.status_code}"
+            f"Caused by: '{response.text}'. Code: {response.status_code}"
         )
 
         return token

--- a/kf_lib_data_ingest/network/utils.py
+++ b/kf_lib_data_ingest/network/utils.py
@@ -75,7 +75,7 @@ def http_get_file(url, dest_obj, **kwargs):
         logger.info(success_msg)
 
     else:
-        logger.error(f"Could not fetch {url}. Caused by " f"{response.text}")
+        logger.error(f"Could not fetch {url}. Caused by: '{response.text}'")
 
     return response
 

--- a/tests/test_file_retriever.py
+++ b/tests/test_file_retriever.py
@@ -391,7 +391,6 @@ def _assert_file(storage_dir, file_path):
     Assert that a file exists at file_path
     """
     assert os.path.commonpath([storage_dir, file_path]) == storage_dir
-
     assert os.path.isfile(file_path)
 
 
@@ -414,3 +413,20 @@ def test_static_auth_configs():
     exec(test_code, test_module.__dict__)
     test_module.test_static_auth_configs()
     fr.static_auth_configs = None
+
+
+def test_data_available_after_file_cleanup():
+    # `read_file(FileRetriever().get("foo"))` should always work even though
+    # the local copy disappears when the FR leaves scope.
+    url = "file://" + TEST_FILE_PATH
+    fr = FileRetriever()
+    fr_dir = fr.storage_dir
+    fo = fr.get(url)
+    assert os.path.exists(fr_dir)
+    assert os.path.exists(fo.name)
+    data = fo.read()
+    del fr
+    assert not os.path.exists(fr_dir)
+    assert not os.path.exists(fo.name)
+    fo.seek(0)
+    assert fo.read() == data


### PR DESCRIPTION
Add a test to stop a future change to FileRetriever from breaking functionality that
allows to call FileRetriever().get() as input to a read function even
though the temporary downloads go away when the FR leaves scope.