### PR TITLE
♻️ Deduplicate discovery

### DIFF
--- a/kf_lib_data_ingest/etl/ingest_pipeline.py
+++ b/kf_lib_data_ingest/etl/ingest_pipeline.py
@@ -277,8 +277,6 @@ class DataIngestPipeline(object):
                 ):
                     schema = f"{os.path.basename(self.ingest_config_dir)}/{stage_name}"
                     for df_name, df in output.items():
-                        if isinstance(stage, ExtractStage):
-                            df = df[1]
                         persist_df_to_study_db(
                             self.warehouse_db_url,
                             self.data_ingest_config.study,

--- a/kf_lib_data_ingest/etl/transform/transform.py
+++ b/kf_lib_data_ingest/etl/transform/transform.py
@@ -33,7 +33,7 @@ class TransformStage(IngestStage):
             if filename.endswith(".tsv")
         }
         self.logger.info(
-            f"Reading {type(self).__name__} output:\n"
+            f"Reading {self.stage_type.__name__} output:\n"
             f"{pformat(list(output.keys()))}"
         )
 
@@ -59,7 +59,7 @@ class TransformStage(IngestStage):
             df.to_csv(fp, sep="\t", index=False)
 
         self.logger.info(
-            f"Writing {type(self).__name__} output:\n" f"{pformat(paths)}"
+            f"Writing {self.stage_type.__name__} output:\n" f"{pformat(paths)}"
         )
 
     def _validate_run_parameters(self, data_dict):
@@ -85,7 +85,7 @@ class TransformStage(IngestStage):
             assert_all_safe_type(data_dict.keys(), str)
 
             # Check that values are tuples of (string, DataFrames)
-            for extract_config_url, df in data_dict.values():
+            for extract_config_url, df in data_dict.items():
                 assert_safe_type(extract_config_url, str)
                 assert_safe_type(df, pandas.DataFrame)
 
@@ -107,11 +107,5 @@ class TransformStage(IngestStage):
         ExtractStage.run. See TransformStage._validate_run_parameters for
         a more detailed description.
         :type data_dict: dict
-        """
-        pass
-
-    def _postrun_concept_discovery(self, run_output):
-        """
-        See the docstring for IngestStage._postrun_concept_discovery
         """
         pass

--- a/tests/test_extract_stage.py
+++ b/tests/test_extract_stage.py
@@ -70,7 +70,7 @@ def test_extracts():
         df_out = es.run()
         recycled_output = es.read_output()
         for config in extract_configs:
-            extracted = df_out[os.path.basename(config)][1]
+            extracted = df_out[os.path.basename(config)]
             expected = es._source_file_to_df(
                 "file://"
                 + os.path.join(
@@ -86,7 +86,7 @@ def test_extracts():
 
             # test serialize/deserialize equivalence
             A, B = rectify_cols_and_datatypes(
-                extracted, recycled_output[os.path.basename(config)][1]
+                extracted, recycled_output[os.path.basename(config)]
             )
             pandas.testing.assert_frame_equal(A, B)
 

--- a/tests/test_transform_stage.py
+++ b/tests/test_transform_stage.py
@@ -48,14 +48,14 @@ def test_invalid_run_parameters(guided_transform_stage, **kwargs):
 
     # Bad values
     with pytest.raises(InvalidIngestStageParameters):
-        guided_transform_stage.run({"foor": ("bar", None) for i in range(5)})
+        guided_transform_stage.run({"foor": None for i in range(5)})
 
 
 def test_read_write(guided_transform_stage, df):
     """
     Test TransformStage.read_output/write_output
     """
-    extract_output = {"extract_config_url": ("source_url", df)}
+    extract_output = {"extract_config_url": df}
 
     # Transform outputs json
     output = guided_transform_stage.run(extract_output)


### PR DESCRIPTION
This also removes source files from the Extract output, which I've been
meaning to do for a while. Extract configs can load arbitrary data from
anywhere at any time, not just the designated variable, so it's
misleading to indicate otherwise.