### PR TITLE
👽 Use token auth for prod study creator

### DIFF
--- a/kf_lib_data_ingest/app/settings/base.py
+++ b/kf_lib_data_ingest/app/settings/base.py
@@ -1,3 +1,6 @@
+"""
+Base settings for Kids First Ingest App
+"""
 import os
 
 from kf_lib_data_ingest.config import ROOT_DIR
@@ -12,14 +15,18 @@ class SECRETS:
 
 
 AUTH_CONFIGS = {
-    "http://localhost:8080/download/study": {
-        "type": "token",
-        "token_location": "url",
-        "token": os.environ.get(SECRETS.KF_STUDY_CREATOR_API_TOKEN),
-    },
-    "http://kf-study-creator-dev.kids-first.io/download/study": {
-        "type": "token",
-        "token_location": "url",
-        "token": os.environ.get(SECRETS.KF_STUDY_CREATOR_API_TOKEN),
-    },
+    # "http://localhost:8080/token/download": {
+    #     "type": "token",
+    #     "token_location": "url",
+    #     "token": os.environ.get(SECRETS.KF_STUDY_CREATOR_API_TOKEN),
+    # },
+    # "https://localhost:8080/oath2/download": {
+    #     "type": "oauth2",
+    #     "provider_domain": os.environ.get("KF_AUTH0_DOMAIN"),
+    #     "audience": os.environ.get("KF_STUDY_CREATOR_AUTH0_AUD"),
+    #     "client_id": os.environ.get("KF_SC_INGEST_APP_CLIENT_ID"),
+    #     "client_secret": os.environ.get(
+    #         SECRETS.KF_SC_INGEST_APP_CLIENT_SECRET
+    #     ),
+    # },
 }

--- a/kf_lib_data_ingest/app/settings/development.py
+++ b/kf_lib_data_ingest/app/settings/development.py
@@ -4,19 +4,26 @@ Development settings for Kids First Ingest App
 import os
 
 from kf_lib_data_ingest.app.settings.base import (
-    AUTH_CONFIGS,
     SECRETS,
     TARGET_API_CONFIG,
 )
 
 TARGET_API_CONFIG = TARGET_API_CONFIG
 
-AUTH_CONFIGS.update(
-    {
-        "https://kf-study-creator.kidsfirstdrc.org/download/study": {
-            "type": "token",
-            "token_location": "header",
-            "token": os.environ.get(SECRETS.KF_STUDY_CREATOR_API_TOKEN),
-        }
-    }
-)
+AUTH_CONFIGS = {
+    "http://localhost:8080/download/study": {
+        "type": "token",
+        "token_location": "url",
+        "token": os.environ.get(SECRETS.KF_STUDY_CREATOR_API_TOKEN),
+    },
+    "http://kf-study-creator-dev.kids-first.io/download/study": {
+        "type": "token",
+        "token_location": "header",
+        "token": os.environ.get(SECRETS.KF_STUDY_CREATOR_API_TOKEN),
+    },
+    "https://kf-study-creator.kidsfirstdrc.org/download/study": {
+        "type": "token",
+        "token_location": "header",
+        "token": os.environ.get(SECRETS.KF_STUDY_CREATOR_API_TOKEN),
+    },
+}

--- a/kf_lib_data_ingest/app/settings/production.py
+++ b/kf_lib_data_ingest/app/settings/production.py
@@ -4,23 +4,16 @@ Production settings for Kids First Ingest App
 import os
 
 from kf_lib_data_ingest.app.settings.base import (
-    AUTH_CONFIGS,
     SECRETS,
     TARGET_API_CONFIG,
 )
 
 TARGET_API_CONFIG = TARGET_API_CONFIG
 
-AUTH_CONFIGS.update(
-    {
-        "https://kf-study-creator.kidsfirstdrc.org/download/study": {
-            "type": "oauth2",
-            "provider_domain": os.environ.get("KF_AUTH0_DOMAIN"),
-            "audience": os.environ.get("KF_STUDY_CREATOR_AUTH0_AUD"),
-            "client_id": os.environ.get("KF_SC_INGEST_APP_CLIENT_ID"),
-            "client_secret": os.environ.get(
-                SECRETS.KF_SC_INGEST_APP_CLIENT_SECRET
-            ),
-        }
-    }
-)
+AUTH_CONFIGS = {
+    "https://kf-study-creator.kidsfirstdrc.org/download/study": {
+        "type": "token",
+        "token_location": "header",
+        "token": os.environ.get(SECRETS.KF_STUDY_CREATOR_API_TOKEN),
+    },
+}


### PR DESCRIPTION
The study creator is moving away from oath2.

closes #461

part of d3b-center/clinical-data-flow#102  