### PR TITLE
⬆️ Upgrade click dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Click==7.0
+Click==7.1.2
 jsonschema==3.1.1
 numpy==1.17.3
 pandas==1.0.5


### PR DESCRIPTION
> black 20.8b1 requires click>=7.1.2, but you'll have click 7.0 which is incompatible.