### PR TITLE
🐛 comment out bool json type cast

### DIFF
--- a/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
+++ b/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
@@ -646,7 +646,6 @@ all_targets = [
 
 swagger_cache = {}
 json_type_casts = {
-    "boolean": bool,
     "string": str,
     "integer": int,
     "number": float,


### PR DESCRIPTION
making a pr to get the ball rolling on the issue i found with booleans. 

When ingesting an ingest package, I found the setting `CONCEPT.GENOMIC_FILE.VISIBLE` to `constants.COMMON.FALSE` created the correct output in `sent_messages.json` but when inspecting in dataservice, visible was set to false.

Commenting out the 'boolean': bool line fixed this.