### PR TITLE
✨ Validation Reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ test_graph.gml
 # dot files and folders
 .*
 
+# validation results
+validation_results/

--- a/kf_lib_data_ingest/common/stage.py
+++ b/kf_lib_data_ingest/common/stage.py
@@ -9,6 +9,7 @@ from kf_lib_data_ingest.validation.validation import (
     Validator,
     check_results,
     RESULTS_FILENAME,
+    VALIDATION_OUTPUT_DIR,
 )
 
 BASIC_VALIDATION = "basic"
@@ -28,6 +29,10 @@ class IngestStage(ABC):
 
         self.logger = logging.getLogger(type(self).__name__)
         self.validation_success = True
+        self.validation_output_dir = os.path.join(
+            self.stage_cache_dir or "",
+            VALIDATION_OUTPUT_DIR,
+        )
 
     @property
     def stage_type(self):
@@ -119,9 +124,7 @@ class IngestStage(ABC):
         """
         Path to validation results file
         """
-        return os.path.join(
-            self.stage_cache_dir, "validation_results", RESULTS_FILENAME
-        )
+        return os.path.join(self.validation_output_dir, RESULTS_FILENAME)
 
     def _log_run(func):
         """

--- a/kf_lib_data_ingest/etl/ingest_pipeline.py
+++ b/kf_lib_data_ingest/etl/ingest_pipeline.py
@@ -289,6 +289,17 @@ class DataIngestPipeline(object):
             else:
                 self.logger.error("⚠️  Ingest failed validation! ")
 
+            report_file_paths = [
+                os.path.join(root, file)
+                for stage in self.stages.values()
+                for root, dirs, files in os.walk(stage.validation_output_dir)
+                for file in files
+                if not file.startswith(".")
+            ]
+            self.logger.info(
+                f"See validation report files:\n{pformat(report_file_paths)}"
+            )
+
         except Exception as e:
             self.logger.exception(str(e))
             self.logger.error(

--- a/kf_lib_data_ingest/validation/reporting/base.py
+++ b/kf_lib_data_ingest/validation/reporting/base.py
@@ -1,0 +1,242 @@
+"""
+Abstract base class for validation report builders
+"""
+import os
+import logging
+from abc import ABC, abstractmethod
+from pprint import pformat
+
+from kf_lib_data_ingest.common.type_safety import (
+    assert_safe_type,
+    assert_all_safe_type,
+)
+
+SAMPLE_VALIDATION_RESULTS = os.path.abspath("./sample_validation_results.py")
+PASSED = "success"
+FAILED = "fail"
+NA = "did not run"
+RESULT_TO_EMOJI = {PASSED: "✅", FAILED: "❌", NA: "🔘"}
+
+
+class AbstractReportBuilder(ABC):
+    """
+    Abstract base class defines the required interface for all
+    subclass validation report builders
+
+    Subclasses must implement methods:
+    - `_build`: builds the report content in a particular format
+    - `_write_report`: writes the report content to disk.
+
+    The public `build` method will call `_validate_result_schema` to
+    ensure validation results adhere to the expected the structure/format
+    and then pass the results to the subclass's _build method
+
+    See method docstrings for more details.
+    """
+
+    def __init__(self, output_dir=None, setup_logger=False):
+        """
+        Constructor
+
+        :param output_dir: Directory where validation files will be written
+        :type output_dir: str
+        :param setup_logger: Whether to setup a console logger. Set to True if
+        running standalone
+        :type setup_logger: bool
+        """
+        self.output_dir = output_dir or os.getcwd()
+
+        if setup_logger:
+            root = logging.getLogger()
+            root.setLevel(logging.DEBUG)
+            consoleHandler = logging.StreamHandler()
+            consoleHandler.setFormatter(
+                logging.Formatter(
+                    "%(asctime)s - %(name)s" " - %(levelname)s - %(message)s"
+                )
+            )
+            root.addHandler(consoleHandler)
+
+        self.logger = logging.getLogger(type(self).__name__)
+
+    @abstractmethod
+    def _build(self, results, *args, **kwargs):
+        """
+        Build the validation report content from the validation `results` dict
+        Subclasses must implement this method
+
+        :param results: Validation result dicts.
+
+        See kf_lib_data_ingest.validation.reporting.sample_validation_results.py # noqa E501
+        for expected format
+
+        :type results: list of dicts
+
+        :returns: validation report content to be written to file
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def _write_report(self, content, *args, **kwargs):
+        """
+        Write the validation report content from _build to file(s)
+
+        Subclasses must implement this method
+
+        :param content: Validation report content
+        :type content: Variable. Subclass is responsible to know how to handle
+        the content type
+
+        :returns: File path or directory where files have been written
+        """
+        raise NotImplementedError()
+
+    def build(self, results, **report_kwargs):
+        """
+        Ensure `results` adheres to expected structure/format
+        Build validation report content from validation result dicts
+        Write validation report files to disk
+
+        :param results: See _build
+        :type results: See _build
+        :param report_kwargs: Keyword args passed to subclass _build
+        (e.g. title='My Validation Report')
+        :type report_kwargs: dict
+
+        :returns: Validation report content to be written to file
+        """
+        self.logger.debug(
+            "Checking validation results for schema conformance ..."
+        )
+
+        self._validate_result_schema(results)
+
+        self.logger.info("Begin building validation report ...")
+        output = self._build(results, **report_kwargs)
+
+        # Write validation report files
+        return self.write_report(output)
+
+    def write_report(self, content):
+        """
+        Write validation report file(s) and log files written
+
+        :param content: Validation report content
+        :type content: Variable. Subclass is responsible to know how to handle
+        the content type
+        """
+        path = self._write_report(content)
+        if os.path.isdir(path):
+            paths = [os.path.join(path, fp) for fp in os.listdir(path)]
+        else:
+            paths = [path]
+
+        for p in paths:
+            self.logger.info(f"Wrote validation report file: {p}")
+
+        return paths
+
+    def _validate_result_schema(self, results):
+        """
+        Validate structure and format of validation test result dicts
+
+        :param results: Validation result dicts.
+
+        See kf_lib_data_ingest.validation.reporting.sample_validation_results.py # noqa E501
+        for expected format
+
+        :type results: list of dicts
+        """
+        req_keys = {'counts', 'files_validated', 'validation'}
+        req_result_keys = {
+            "type", "description", "is_applicable", "errors", "inputs"
+        }
+
+        assert_safe_type(results["counts"], dict)
+        assert_safe_type(results["files_validated"], list)
+        assert_safe_type(results["validation"], list)
+
+        # Check for top level required keys by attempting to access all
+        # expected keys
+        try:
+            for k in req_keys:
+                results[k]
+        except KeyError:
+            self.logger.error(
+                f"Validation results dict has keys: "
+                f"{pformat(results.keys())} but is missing one or more "
+                f"required keys: {pformat(req_keys)}"
+            )
+            raise
+
+        # Check for validation result dict required keys by attempting to
+        # access all expected keyss
+        try:
+            for r in results['validation']:
+                for k in req_result_keys:
+                    r[k]
+        except KeyError:
+            self.logger.error(
+                f"Validation test result dict:\n{pformat(r)}"
+                "\n is missing one or more required keys: "
+                f"{pformat(req_result_keys)}"
+            )
+            raise
+
+            # Check types
+            assert_safe_type(r["type"], str)
+            assert_safe_type(r["description"], str)
+            assert_safe_type(r["is_applicable"], bool)
+            assert_safe_type(r["errors"], list, dict)
+
+            # -- Check error dicts --
+            # Ensure error dicts follow expected structure by attempting to
+            # access all keys and values. Catch any exception, log that there
+            # was a validation error in the validation result's error dict,
+            # re-raise the original exception
+            try:
+                errs = r["errors"]
+                if r["type"] == "relationship":
+                    for e in errs:
+                        t, v = e["from"]
+                        if e["to"]:
+                            for to_node in e["to"]:
+                                t1, v1 = to_node
+                        for (t2, v2), files in e["locations"].items():
+                            pass
+                elif r["type"] == "attribute":
+                    assert_all_safe_type(errs.keys(), str)
+                    assert_all_safe_type(errs.values(), set)
+
+                elif r["type"] == "count":
+                    assert_all_safe_type(errs.keys(), str)
+                    assert_all_safe_type(errs.values(), int)
+
+            except Exception:
+                self.logger.error(
+                    "Badly formatted `errors` in validation result dict: "
+                    f"\n{pformat(r)}\n"
+                    f"Please see {SAMPLE_VALIDATION_RESULTS} "
+                    f"for expected validation results format."
+                )
+                raise
+
+    def _result_code(self, result_dict):
+        """
+        Evaluate fields in validation result dict to determine test outcome
+        code
+
+        :param result_dict: validation result dict
+        :type result_dict: dict
+        """
+        # Did not run
+        if not result_dict["is_applicable"]:
+            code = NA
+        # Failed
+        elif result_dict["is_applicable"] and result_dict["errors"]:
+            code = FAILED
+        # Passed
+        else:
+            code = PASSED
+
+        return code

--- a/kf_lib_data_ingest/validation/reporting/base.py
+++ b/kf_lib_data_ingest/validation/reporting/base.py
@@ -131,8 +131,7 @@ class AbstractReportBuilder(ABC):
         else:
             paths = [path]
 
-        for p in paths:
-            self.logger.info(f"Wrote validation report file: {p}")
+        self.logger.info(f"Wrote validation report file(s):\n{pformat(paths)}")
 
         return paths
 

--- a/kf_lib_data_ingest/validation/reporting/base.py
+++ b/kf_lib_data_ingest/validation/reporting/base.py
@@ -147,9 +147,13 @@ class AbstractReportBuilder(ABC):
 
         :type results: list of dicts
         """
-        req_keys = {'counts', 'files_validated', 'validation'}
+        req_keys = {"counts", "files_validated", "validation"}
         req_result_keys = {
-            "type", "description", "is_applicable", "errors", "inputs"
+            "type",
+            "description",
+            "is_applicable",
+            "errors",
+            "inputs",
         }
 
         assert_safe_type(results["counts"], dict)
@@ -172,7 +176,7 @@ class AbstractReportBuilder(ABC):
         # Check for validation result dict required keys by attempting to
         # access all expected keyss
         try:
-            for r in results['validation']:
+            for r in results["validation"]:
                 for k in req_result_keys:
                     r[k]
         except KeyError:

--- a/kf_lib_data_ingest/validation/reporting/markdown.py
+++ b/kf_lib_data_ingest/validation/reporting/markdown.py
@@ -145,6 +145,7 @@ class MarkdownReportBuilder(AbstractReportBuilder):
         Helper method for _tests_section_md. Convert single test result dict
         into markdown formatted str
         """
+
         def _style(val):
             """
             Style string val to make it stand out in a markdown doc
@@ -268,11 +269,9 @@ class MarkdownReportBuilder(AbstractReportBuilder):
             # Rollup errors into 1 line when a large enough % of from_nodes are
             # linked to 0 to_nodes (e.g. All PARTICIPANT.ID are linked to [])
             if (
-                (error_count >= ERROR_COUNT_THRESHOLD) and
-                (error_fraction >= ERROR_FRAC_THRESHOLD) and
-                all(
-                    [not e["to"] for e in rd["errors"]]
-                )
+                (error_count >= ERROR_COUNT_THRESHOLD)
+                and (error_fraction >= ERROR_FRAC_THRESHOLD)
+                and all([not e["to"] for e in rd["errors"]])
             ):
                 err_rollup = True
                 error_rows = [

--- a/kf_lib_data_ingest/validation/reporting/markdown.py
+++ b/kf_lib_data_ingest/validation/reporting/markdown.py
@@ -1,0 +1,325 @@
+"""
+Markdown validation report builder
+Produces a human friendly markdown based validation report
+
+Extends kf_lib_data_ingest.validation.reporting.base.AbstractReportBuilder
+"""
+import os
+from collections import defaultdict
+import pandas
+
+from kf_lib_data_ingest.validation.reporting.base import (
+    AbstractReportBuilder,
+    RESULT_TO_EMOJI,
+    PASSED,
+    FAILED,
+    NA,
+)
+
+DEFAULT_REPORT_TITLE = "📓 Data Validation Report"
+RESULTS_FILENAME = "validation_results.md"
+REPLACE_PIPE = "."
+ERROR_FRAC_THRESHOLD = .50
+ERROR_COUNT_THRESHOLD = 50
+
+
+class MarkdownReportBuilder(AbstractReportBuilder):
+    def __init__(self, output_dir=None, setup_logger=False):
+        """
+        Constructor
+
+        See AbstractReportBuilder.__init__
+        """
+        super().__init__(output_dir=output_dir, setup_logger=setup_logger)
+
+    def _build(self, results, title=DEFAULT_REPORT_TITLE):
+        """
+        Build markdown content for validation report
+
+        :param results: See AbstractReportBuilder._build
+        :param type: See AbstractReportBuilder._build
+        :param title: Report title
+        :type title: str
+        """
+        self.counts = results['counts']
+        self.files_validated = results['files_validated']
+        self.results = results['validation']
+
+        output = []
+        output.append(f"# {title}")
+        output.append("## 📂 Files Validated")
+        output.append(self._files_md(results))
+        output.append("\n##  #️⃣  Counts")
+        output.append(self._counts_md(results))
+        output.append("\n## 🚦 Relationship Tests")
+        output.append(self._tests_section_md(results, "relationship"))
+        output.append("\n## 🚦 Gap Tests")
+        output.append(self._tests_section_md(results, "gap"))
+        output.append("\n## 🚦 Attribute Value Tests")
+        output.append(self._tests_section_md(results, "attribute"))
+        output.append("\n## 🚦 Count Tests")
+        output.append(self._tests_section_md(results, "count"))
+        output = "\n".join(output)
+
+        return output
+
+    def _write_report(self, content):
+        """
+        Write markdown validation report file to disk
+        """
+        output_path = os.path.join(self.output_dir, RESULTS_FILENAME)
+        with open(output_path, "w") as md_file:
+            md_file.write(content)
+        return output_path
+
+    def _test_header(self, result_dict):
+        """
+        Create validation test header from a test result dict
+
+        :param result_dict: See sample_validation_results.py
+        :type results: dict
+
+        :returns: markdown formatted str
+        """
+        header = (
+            f"{RESULT_TO_EMOJI.get(self._result_code(result_dict))} "
+            f'{result_dict["description"]}'
+        ).replace('|', REPLACE_PIPE)
+
+        # Make test header stand out for tests that ran
+        if result_dict['is_applicable']:
+            header = f'#### {header}'
+
+        return header
+
+    def _tests_section_md(self, results, test_type):
+        """
+        Create markdown section containing test results for a given
+        test type: [count | attribute | relationship | gap]
+
+        :param results: See sample_validation_results.py for `results` format
+        :type results: list of dicts
+        :param test_type: Type of validation test
+        (e.g. attribute, relationship, count)
+        :type test_type: str
+
+        :returns: markdown formatted str
+        """
+        output = []
+        results = results["validation"]
+
+        # Build markdown for each test section
+        test_markdowns = defaultdict(list)
+        for r in results:
+            if r["type"] != test_type:
+                continue
+
+            self.logger.debug(
+                f"Building results for {r['description']}"
+            )
+            # Build markdown for each test result
+            test_markdowns[self._result_code(r)].append(
+                self._result_to_md(r, test_type)
+            )
+
+        # Add test section summary
+        test_order_by_outcome = [FAILED, PASSED, NA]
+        summary = " ".join(
+            [
+                f"`{code.title()}: {len(test_markdowns.get(code, []))}`"
+                for code in test_order_by_outcome
+            ]
+        )
+        output.append(f"### {summary}")
+
+        # Add test markdowns
+        for result_code in test_order_by_outcome:
+            tm = test_markdowns.get(result_code, [])
+            output.extend(tm)
+
+        return "\n".join(output)
+
+    def _result_to_md(self, rd, test_type):
+        """
+        Helper method for _tests_section_md. Convert single test result dict
+        into markdown formatted str
+        """
+        test_markdown = []
+
+        def _style(val):
+            """
+            Style string val to make it stand out in a markdown doc
+            Replace | char with .
+            """
+            return f'`{str(val).replace("|", REPLACE_PIPE)}`'
+
+        def tuple_to_str(t):
+            """
+            Turn (type, value) concept into a string (e.g. `PARTICIPANT.ID`)
+            """
+            return _style(REPLACE_PIPE.join(t))
+
+        # Add test header - [result emoji] [test description]
+        test_markdown.append("")
+        test_markdown.append(self._test_header(rd))
+        test_markdown.append("")
+
+        # If test has no errors, just return test header
+        if not rd["errors"]:
+            return "\n".join(test_markdown)
+
+        # Add test errors and locations
+        if test_type == "count":
+            test_markdown.append(
+                f'Found: {_style(rd["errors"]["found"])} '
+                f'but expected: {_style(rd["errors"]["expected"])}'
+            )
+
+        elif test_type == "attribute":
+            test_markdown.append(
+                pandas.DataFrame(
+                    [
+                        {
+                            "Location": os.path.basename(file_path),
+                            "Bad Values": ','.join(
+                                sorted([_style(v) for v in bad_vals])
+                            )
+                        }
+                        for file_path, bad_vals in rd["errors"].items()
+                    ]
+                ).to_markdown(index=False)
+            )
+
+        elif test_type == "gap":
+            # TODO
+            pass
+
+        elif test_type == "relationship":
+            errors = []
+            locs = defaultdict(set)
+
+            # -- Errors --
+            err_rollup = False
+            from_type = rd['inputs']['from']
+            to_type = rd['inputs']['to']
+            error_fraction = len(rd['errors']) / self.counts[from_type]
+
+            # Rollup errors into 1 line when a large enough % of from_nodes are
+            # linked to 0 to_nodes (e.g. All PARTICIPANT.ID are linked to [])
+            if (
+                error_fraction >= ERROR_FRAC_THRESHOLD and
+                all([not e['to'] for e in errors])
+            ):
+                err_rollup = True
+                if error_fraction == 1:
+                    prefix = 'All'
+                else:
+                    prefix = f"More than {error_fraction * 100} of "
+
+                errors.append(
+                    {
+                        "Errors": f"{prefix} {self.counts[from_type]} "
+                        f"{_style(from_type)} in the dataset "
+                        f"are linked to 0 {_style(to_type)}"
+                    }
+                )
+            # Create formatted error strings
+            else:
+                for e in rd["errors"]:
+                    prefix = f"{tuple_to_str(e['from'])} is linked to "
+                    if e["to"]:
+                        suffix = [f"{_style(to_node[1])}" for to_node in e["to"]]
+                    else:
+                        suffix = f"0 {_style(rd['inputs']['to'])}"
+
+                    errors.append({"Errors": f"{prefix} {suffix}"})
+
+            test_markdown.append(
+                pandas.DataFrame(errors).to_markdown(index=False)
+            )
+
+            # -- File locations --
+            # Organize error values by file they were found in
+            for e in rd['errors']:
+                for (typ, val), files in e["locations"].items():
+                    for f in files:
+                        locs[f].add(f'{_style(val)}')
+
+            # Rollup locations - if number of error values in a file ==
+            # number of total errors for the test, then don't list out every
+            # error value in that file
+            loc_rows = []
+            for loc, vals in locs.items():
+                if len(vals) == len(rd['errors']):
+                    val_str = 'File contains all error values in **Errors** table above.'
+                else:
+                    val_str = ','.join(sorted(vals))
+                loc_rows.append(
+                    {
+                        'Location': os.path.basename(loc),
+                        'Values': val_str
+                    }
+                )
+
+            # Don't show file locations when there are too many errors and
+            # we've rolled up the errors into a 1 line error statement
+            if not err_rollup:
+                test_markdown.append("")
+                test_markdown.append(
+                    pandas.DataFrame(loc_rows)
+                    .sort_values(by='Location')
+                    .to_markdown(index=False)
+                )
+
+        return "\n".join(test_markdown)
+
+    def _counts_md(self, results):
+        """
+        Create markdown formatted table of entity type counts
+
+        :param results: See sample_validation_results.py for `results` format
+        :type results: list of dicts
+
+        :returns: markdown formatted str
+        """
+        return (
+            pandas.DataFrame(
+                [
+                    {"Entity": typ, "Count": count}
+                    for typ, count in results["counts"].items()
+                ]
+            ).replace(r"\|", REPLACE_PIPE, regex=True)
+            .sort_values('Count', ascending=False)
+            .to_markdown(index=False)
+        )
+
+    def _files_md(self, results):
+        """
+        Create markdown formatted table of files evaluated
+
+        :param results: See sample_validation_results.py for `results` format
+        :type results: list of dicts
+
+        :returns: markdown formatted str
+        """
+        output = []
+
+        # Organize files by directory
+        files = defaultdict(set)
+        for file in self.files_validated:
+            d, fn = os.path.split(file)
+            files[d].add(fn)
+
+        for d, file_names in files.items():
+            output.append(f'**{d}**\n')
+            output.append(
+                pandas.DataFrame(
+                    [
+                        {'Files': fn}
+                        for fn in file_names
+                    ]
+                ).sort_values(by='Files').to_markdown(index=False)
+            )
+            output.append('')
+
+        return "\n".join(output)

--- a/kf_lib_data_ingest/validation/reporting/markdown.py
+++ b/kf_lib_data_ingest/validation/reporting/markdown.py
@@ -23,8 +23,7 @@ REL_TEST = "relationship"
 GAP_TEST = "gaps"
 ATTR_TEST = "attribute"
 COUNT_TEST = "count"
-ERROR_FRAC_THRESHOLD = 0.50
-ERROR_COUNT_THRESHOLD = 20
+ROW_LIMIT = 20
 
 
 class MarkdownReportBuilder(AbstractReportBuilder):
@@ -187,9 +186,9 @@ class MarkdownReportBuilder(AbstractReportBuilder):
             Transform location dicts into formatted location strings
             Return list of location row dicts for DataFrame
             """
-            locs = defaultdict(set)
             # -- File locations --
             # Organize error values by file they were found in
+            locs = defaultdict(set)
             for e in result_dict["errors"]:
                 for (typ, val), files in e["locations"].items():
                     for f in files:
@@ -199,17 +198,17 @@ class MarkdownReportBuilder(AbstractReportBuilder):
                             val = _style(val)
                         locs[f].add(val)
 
-            # Rollup locations - if number of error values in a file ==
-            # number of total errors for the test, then don't list out every
-            # error value in that file
             loc_rows = []
             for loc, vals in locs.items():
+                # Rollup locations - if number of error values in a file ==
+                # number of total errors for the test, then don't list out
+                # every error value in that file
                 if len(vals) == len(rd["errors"]):
                     val_str = "This file contains all errors in the **Errors** table above."
                 else:
                     val_str = ",".join(sorted(vals))
                 loc_rows.append(
-                    {"Location": os.path.basename(loc), "Values": val_str}
+                    {"Locations": os.path.basename(loc), "Values": val_str}
                 )
             return loc_rows
 
@@ -232,31 +231,36 @@ class MarkdownReportBuilder(AbstractReportBuilder):
 
         elif test_type == ATTR_TEST:
             test_markdown.append(
-                pandas.DataFrame(
-                    [
-                        {
-                            "Location": os.path.basename(file_path),
-                            "Bad Values": ",".join(
-                                sorted([_style(v) for v in bad_vals])
-                            ),
-                        }
-                        for file_path, bad_vals in rd["errors"].items()
-                    ]
-                ).to_markdown(index=False)
+                self._df_to_markdown(
+                    pandas.DataFrame(
+                        [
+                            {
+                                "Locations": os.path.basename(file_path),
+                                "Bad Values": ",".join(
+                                    sorted([_style(v) for v in bad_vals])
+                                ),
+                            }
+                            for file_path, bad_vals in rd["errors"].items()
+                        ]
+                    ),
+                )
             )
         elif test_type == GAP_TEST:
             # Errors
             test_markdown.append(
-                pandas.DataFrame(
-                    _format_errors(rd, include_node_type=True)
-                ).to_markdown(index=False)
+                self._df_to_markdown(
+                    pandas.DataFrame(
+                        _format_errors(rd, include_node_type=True)
+                    ).sort_values(by="Errors"),
+                )
             )
-            test_markdown.append("")
             # File locations
             test_markdown.append(
-                pandas.DataFrame(_format_locations(rd, include_node_type=True))
-                .sort_values(by="Location")
-                .to_markdown(index=False)
+                self._df_to_markdown(
+                    pandas.DataFrame(
+                        _format_locations(rd, include_node_type=True)
+                    ).sort_values(by="Locations"),
+                )
             )
 
         elif test_type == REL_TEST:
@@ -264,45 +268,87 @@ class MarkdownReportBuilder(AbstractReportBuilder):
             err_rollup = False
             from_type = rd["inputs"]["from"]
             to_type = rd["inputs"]["to"]
-            error_count = len(rd["errors"])
-            error_fraction = error_count / self.counts[from_type]
 
-            # Rollup errors into 1 line when a large enough % of from_nodes are
-            # linked to 0 to_nodes (e.g. All PARTICIPANT.ID are linked to [])
-            if (
-                (error_count >= ERROR_COUNT_THRESHOLD)
-                and (error_fraction >= ERROR_FRAC_THRESHOLD)
-                and all([not e["to"] for e in rd["errors"]])
+            # Rollup error dicts into 1 line when all from_nodes are
+            # linked to 0 to_nodes (e.g.
+            # All PARTICIPANT.ID are linked to 0 FAMILY.ID)
+            if (len(rd["errors"]) == self.counts[from_type]) and all(
+                [not e["to"] for e in rd["errors"]]
             ):
                 err_rollup = True
                 error_rows = [
                     {
-                        "Errors": f"At least {error_fraction * 100} % of "
-                        f"{self.counts[from_type]} "
+                        "Errors": f"All {self.counts[from_type]} "
                         f"{_style(from_type)} in the dataset "
                         f"are linked to 0 {_style(to_type)}"
                     }
                 ]
-            # Create formatted error strings
+            # Transform each error dict into markdown text
             else:
                 error_rows = _format_errors(rd)
 
             test_markdown.append(
-                pandas.DataFrame(error_rows).to_markdown(index=False)
+                self._df_to_markdown(
+                    pandas.DataFrame(error_rows).sort_values(by="Errors"),
+                )
             )
 
             # -- File locations --
-            # Only show file locations when we have not rolled up the
-            # errors into a 1 line error statement
-            if not err_rollup:
-                test_markdown.append("")
-                test_markdown.append(
-                    pandas.DataFrame(_format_locations(rd))
-                    .sort_values(by="Location")
-                    .to_markdown(index=False)
+            # Table of file paths - show this when we've rolled up errors
+            if err_rollup:
+                location_rows = [
+                    {"Locations": row["Locations"]}
+                    for row in _format_locations(rd)
+                ]
+            # Table of file paths and error nodes
+            else:
+                location_rows = _format_locations(rd)
+
+            test_markdown.append(
+                self._df_to_markdown(
+                    pandas.DataFrame(location_rows).sort_values(by="Locations"),
                 )
+            )
 
         return "\n".join(test_markdown)
+
+    def _df_to_markdown(self, df, **to_markdown_kwargs):
+        """
+        Transform pandas.DataFrame into markdown text. If number of DataFrame
+        rows is >= ROW_LIMIT, encapsulate the table in a collapsible markdown
+        section
+        :param df: the df to transform
+        :type df: pandas.DataFrame,
+        :param table_name: optional name of table to include in collapsible
+        summary
+        :type table_name: str,
+        :param to_markdown_kwargs: Keyword args forwarded to
+        pandas.DataFrame.to_markdown
+        :type to_markdown_kwargs: dict
+
+        :returns: markdown formatted string
+        """
+        output = []
+
+        # DataFrame to markdown table
+        if "index" not in to_markdown_kwargs:
+            to_markdown_kwargs["index"] = False
+        md_table = df.to_markdown(**to_markdown_kwargs)
+
+        # Encapsulate table in collapsible section if we have too many rows
+        if len(df) >= ROW_LIMIT:
+            output.append("<details>")
+            output.append("<summary><b>Click to expand table</b></summary>")
+            output.append("")
+            output.append(f"{md_table}")
+            output.append("")
+            output.append("</details>")
+            output.append("")
+        else:
+            output.append("")
+            output.append(md_table)
+
+        return "\n".join(output)
 
     def _counts_md(self, results):
         """
@@ -313,7 +359,7 @@ class MarkdownReportBuilder(AbstractReportBuilder):
 
         :returns: markdown formatted str
         """
-        return (
+        return self._df_to_markdown(
             pandas.DataFrame(
                 [
                     {"Entity": typ, "Count": count}
@@ -321,8 +367,7 @@ class MarkdownReportBuilder(AbstractReportBuilder):
                 ]
             )
             .replace(r"\|", REPLACE_PIPE, regex=True)
-            .sort_values("Count", ascending=False)
-            .to_markdown(index=False)
+            .sort_values(by="Count", ascending=False),
         )
 
     def _files_md(self, results):
@@ -343,11 +388,15 @@ class MarkdownReportBuilder(AbstractReportBuilder):
             files[d].add(fn)
 
         for d, file_names in files.items():
-            output.append(f"**{d}**\n")
+            output.append("<br>")
+            output.append("")
+            output.append(f"**{d}**")
             output.append(
-                pandas.DataFrame([{"Files": fn} for fn in file_names])
-                .sort_values(by="Files")
-                .to_markdown(index=False)
+                self._df_to_markdown(
+                    pandas.DataFrame(
+                        [{"Files": fn} for fn in file_names]
+                    ).sort_values(by="Files"),
+                )
             )
             output.append("")
 

--- a/kf_lib_data_ingest/validation/reporting/markdown.py
+++ b/kf_lib_data_ingest/validation/reporting/markdown.py
@@ -223,7 +223,7 @@ class MarkdownReportBuilder(AbstractReportBuilder):
             return "\n".join(test_markdown)
 
         # Add test errors and locations
-        if test_type == "count":
+        if test_type == COUNT_TEST:
             test_markdown.append(
                 f'Found: {_style(rd["errors"]["found"])} '
                 f'but expected: {_style(rd["errors"]["expected"])}'

--- a/kf_lib_data_ingest/validation/reporting/markdown.py
+++ b/kf_lib_data_ingest/validation/reporting/markdown.py
@@ -20,8 +20,9 @@ DEFAULT_REPORT_TITLE = "📓 Data Validation Report"
 RESULTS_FILENAME = "validation_results.md"
 REPLACE_PIPE = "."
 REL_TEST = "relationship"
-ATTR_TEST = "attribute"
 GAP_TEST = "gaps"
+ATTR_TEST = "attribute"
+COUNT_TEST = "count"
 ERROR_FRAC_THRESHOLD = 0.50
 ERROR_COUNT_THRESHOLD = 20
 
@@ -98,7 +99,7 @@ class MarkdownReportBuilder(AbstractReportBuilder):
     def _tests_section_md(self, results, test_type):
         """
         Create markdown section containing test results for a given
-        test type: [count | attribute | relationship | gap]
+        test type: [COUNT_TEST | ATTR_TEST | REL_TEST | GAP_TEST]
 
         :param results: See sample_validation_results.py for `results` format
         :type results: list of dicts
@@ -142,8 +143,8 @@ class MarkdownReportBuilder(AbstractReportBuilder):
 
     def _result_to_md(self, rd, test_type):
         """
-        Helper method for _tests_section_md. Convert single test result dict
-        into markdown formatted str
+        Helper method for _tests_section_md
+        Convert single test result dict into markdown formatted text
         """
 
         def _style(val):

--- a/kf_lib_data_ingest/validation/reporting/sample_validation_results.py
+++ b/kf_lib_data_ingest/validation/reporting/sample_validation_results.py
@@ -1,0 +1,156 @@
+"""
+Sample validation results from do_all_validation() in
+kf_lib_data_ingest.validation.data_validator.py
+"""
+
+results = {
+    "counts": {
+        "PARTICIPANT|ID": 10, "BIOSPECIMEN|ID": 20, "FAMILY|ID": 1
+    },
+    "files_validated": ["foo.txt", "bar.txt"],
+    "validation": [
+        # Relationship test example 1 - entity relation test
+        {
+            # Must be one of [ relationship | attribute | count ]
+            "type": "relationship",
+            "description": "Every BIOSPECIMEN|ID must have 1 PARTICIPANT|ID",
+            # Must be one of [ True | False ] True
+            # True means the test ran
+            # False means the test did not run
+            "is_applicable": True,
+            "inputs": {
+                "from": "BIOSPECIMEN|ID",
+                "to": "PARTICIPANT|ID"
+            },
+            # Format for `errors` when type = relationship
+            "errors": [
+                {
+                    # `from` value must be a concept tuple
+                    "from": ("BIOSPECIMEN|ID", "B1"),
+                    # `to` value must be a list of concept tuples
+                    "to": [
+                        ("PARTICIPANT|ID", "P1"),
+                        # 'a;dljfa', bad type
+                        ("PARTICIPANT|ID", "P2"),
+                    ],
+                    # Must be a dict. A key must be a concept tuple and
+                    # its value must be a set of file path stringss
+                    "locations": {
+                        ("BIOSPECIMEN|ID", "B1"): {"foo.txt", "bar.txt"},
+                        ("PARTICIPANT|ID", "P1"): {"foo.txt", "bar.txt"},
+                        ("PARTICIPANT|ID", "P2"): {"foo.txt", "bar.txt"},
+                    },
+                },
+                {
+                    "from": ("BIOSPECIMEN|ID", "B2"),
+                    "to": [],
+                    "locations": {("BIOSPECIMEN|ID", "B2"): {"foo.txt"}},
+                },
+            ],
+        },
+        # Relationship test example 2 - entity attribute relation test
+        {
+            "type": "relationship",
+            "description": "Every PARTICIPANT|ID must have 1 Gender",
+            "is_applicable": True,
+            "inputs": {
+                "from": "PARTICIPANT|ID",
+                "to": "PARTICIPANT|GENDER"
+            },
+            "errors": [
+                {
+                    "from": ("PARTICIPANT|ID", "P2"),
+                    "to": [],
+                    "locations": {("PARTICIPANT|ID", "P2"): {"foo.txt"}},
+                },
+                {
+                    "from": ("PARTICIPANT|ID", "P1"),
+                    "to": [
+                        ("PARTICIPANT|GENDER", "male"),
+                        ("PARTICIPANT|GENDER", "female"),
+                    ],
+                    "locations": {
+                        ("PARTICIPANT|ID", "P1"): {"foo.txt"},
+                        ("PARTICIPANT|GENDER", "male"): {"foo.txt"},
+                        ("PARTICIPANT|GENDER", "female"): {"foo.txt"},
+                    },
+                },
+            ],
+        },
+        # Attribute test example 1 - Success
+        {
+            "type": "relationship",
+            "description": "Every PARTICIPANT|ID must have 1 FAMILY|ID",
+            "is_applicable": True,
+            "inputs": {
+                "from": "PARTICIPANT|ID",
+                "to": "FAMILY|ID"
+            },
+            "errors": [],
+        },
+        # Attribute test example 2 - Failed
+        {
+            "type": "attribute",
+            "description": "PARTICIPANT|GENDER must be one of: Male, Female",
+            "is_applicable": True,
+            "inputs": {
+                "from": "PARTICIPANT|GENDER"
+            },
+            # Format for `errors` when type = attribute
+            # A key must be a file path str and its value must be a
+            # set of invalid values
+            "errors": {"foo.txt": {"mae", "blah", "M", "f"}, "bar.txt": {"m"}},
+        },
+        # Attribute test example 3 - Failed
+        {
+            "type": "attribute",
+            "description": "BIOSPECIMEN|VOLUME_ML must be >= 0 mL",
+            "is_applicable": True,
+            "inputs": {
+                "from": "BIOSPECIMEN|VOLUME_ML"
+            },
+            "errors": {"foo.txt": {-12123}, "bar.txt": {-1}},
+        },
+        # Attribute test example 4 - Did not run
+        {
+            "type": "attribute",
+            "description": "BIOSPECIMEN|ANALYTE_TYPE must be one of {DNA, RNA}",
+            "is_applicable": False,
+            "inputs": {
+                "from": "BIOSPECIMEN|ANALYTE_TYPE"
+            },
+            "errors": {},
+        },
+        # Count test example 1 - Success
+        {
+            "type": "count",
+            "description": "FAMILY|ID: Found == Expected",
+            "is_applicable": True,
+            "inputs": {
+                "from": "FAMILY|ID"
+            },
+            "errors": {},
+        },
+        # Count test example 2 - Failed
+        {
+            "type": "count",
+            "description": "PARTICIPANT|ID: Found == Expected",
+            "is_applicable": True,
+            "inputs": {
+                "from": "PARTICIPANT|ID"
+            },
+            # Format for `errors` when type = count
+            "errors": {"expected": 10, "found": 20},
+        },
+        # Count test example 3 - Did not run
+        {
+            "type": "count",
+            "description": "BIOSPECIMEN|ID: Found == Expected",
+            "is_applicable": False,
+            "inputs": {
+                "from": "BIOSPECIMEN|ID"
+            },
+            "errors": {},
+        },
+    ],
+}

--- a/kf_lib_data_ingest/validation/reporting/sample_validation_results.py
+++ b/kf_lib_data_ingest/validation/reporting/sample_validation_results.py
@@ -4,9 +4,7 @@ kf_lib_data_ingest.validation.data_validator.py
 """
 
 results = {
-    "counts": {
-        "PARTICIPANT|ID": 10, "BIOSPECIMEN|ID": 20, "FAMILY|ID": 1
-    },
+    "counts": {"PARTICIPANT|ID": 10, "BIOSPECIMEN|ID": 20, "FAMILY|ID": 1},
     "files_validated": ["foo.txt", "bar.txt"],
     "validation": [
         # Relationship test example 1 - entity relation test
@@ -18,10 +16,7 @@ results = {
             # True means the test ran
             # False means the test did not run
             "is_applicable": True,
-            "inputs": {
-                "from": "BIOSPECIMEN|ID",
-                "to": "PARTICIPANT|ID"
-            },
+            "inputs": {"from": "BIOSPECIMEN|ID", "to": "PARTICIPANT|ID"},
             # Format for `errors` when type = relationship
             "errors": [
                 {
@@ -53,10 +48,7 @@ results = {
             "type": "relationship",
             "description": "Every PARTICIPANT|ID must have 1 Gender",
             "is_applicable": True,
-            "inputs": {
-                "from": "PARTICIPANT|ID",
-                "to": "PARTICIPANT|GENDER"
-            },
+            "inputs": {"from": "PARTICIPANT|ID", "to": "PARTICIPANT|GENDER"},
             "errors": [
                 {
                     "from": ("PARTICIPANT|ID", "P2"),
@@ -77,15 +69,29 @@ results = {
                 },
             ],
         },
+        {
+            "type": "gaps",
+            "inputs": {},
+            "description": "All resolved links are hierarchically direct",
+            "is_applicable": True,
+            "errors": [
+                {
+                    "from": ("GENOMIC_FILE|URL_LIST", "['s1.txt']"),
+                    "to": [("PARTICIPANT|ID", "P2"), ("PARTICIPANT|ID", "P1")],
+                    "locations": {
+                        ("GENOMIC_FILE|URL_LIST", "['s1.txt']"): ["fg.csv"],
+                        ("PARTICIPANT|ID", "P2"): ["fp.csv"],
+                        ("PARTICIPANT|ID", "P1"): ["fp.csv"],
+                    },
+                }
+            ]
+        },
         # Attribute test example 1 - Success
         {
             "type": "relationship",
             "description": "Every PARTICIPANT|ID must have 1 FAMILY|ID",
             "is_applicable": True,
-            "inputs": {
-                "from": "PARTICIPANT|ID",
-                "to": "FAMILY|ID"
-            },
+            "inputs": {"from": "PARTICIPANT|ID", "to": "FAMILY|ID"},
             "errors": [],
         },
         # Attribute test example 2 - Failed
@@ -93,9 +99,7 @@ results = {
             "type": "attribute",
             "description": "PARTICIPANT|GENDER must be one of: Male, Female",
             "is_applicable": True,
-            "inputs": {
-                "from": "PARTICIPANT|GENDER"
-            },
+            "inputs": {"from": "PARTICIPANT|GENDER"},
             # Format for `errors` when type = attribute
             # A key must be a file path str and its value must be a
             # set of invalid values
@@ -106,9 +110,7 @@ results = {
             "type": "attribute",
             "description": "BIOSPECIMEN|VOLUME_ML must be >= 0 mL",
             "is_applicable": True,
-            "inputs": {
-                "from": "BIOSPECIMEN|VOLUME_ML"
-            },
+            "inputs": {"from": "BIOSPECIMEN|VOLUME_ML"},
             "errors": {"foo.txt": {-12123}, "bar.txt": {-1}},
         },
         # Attribute test example 4 - Did not run
@@ -116,9 +118,7 @@ results = {
             "type": "attribute",
             "description": "BIOSPECIMEN|ANALYTE_TYPE must be one of {DNA, RNA}",
             "is_applicable": False,
-            "inputs": {
-                "from": "BIOSPECIMEN|ANALYTE_TYPE"
-            },
+            "inputs": {"from": "BIOSPECIMEN|ANALYTE_TYPE"},
             "errors": {},
         },
         # Count test example 1 - Success
@@ -126,9 +126,7 @@ results = {
             "type": "count",
             "description": "FAMILY|ID: Found == Expected",
             "is_applicable": True,
-            "inputs": {
-                "from": "FAMILY|ID"
-            },
+            "inputs": {"from": "FAMILY|ID"},
             "errors": {},
         },
         # Count test example 2 - Failed
@@ -136,9 +134,7 @@ results = {
             "type": "count",
             "description": "PARTICIPANT|ID: Found == Expected",
             "is_applicable": True,
-            "inputs": {
-                "from": "PARTICIPANT|ID"
-            },
+            "inputs": {"from": "PARTICIPANT|ID"},
             # Format for `errors` when type = count
             "errors": {"expected": 10, "found": 20},
         },
@@ -147,9 +143,7 @@ results = {
             "type": "count",
             "description": "BIOSPECIMEN|ID: Found == Expected",
             "is_applicable": False,
-            "inputs": {
-                "from": "BIOSPECIMEN|ID"
-            },
+            "inputs": {"from": "BIOSPECIMEN|ID"},
             "errors": {},
         },
     ],

--- a/kf_lib_data_ingest/validation/reporting/sample_validation_results.py
+++ b/kf_lib_data_ingest/validation/reporting/sample_validation_results.py
@@ -84,7 +84,7 @@ results = {
                         ("PARTICIPANT|ID", "P1"): ["fp.csv"],
                     },
                 }
-            ]
+            ],
         },
         # Attribute test example 1 - Success
         {

--- a/kf_lib_data_ingest/validation/reporting/sample_validation_results.py
+++ b/kf_lib_data_ingest/validation/reporting/sample_validation_results.py
@@ -1,5 +1,5 @@
 """
-Sample validation results from do_all_validation() in
+Sample validation results from Validator.validate in
 kf_lib_data_ingest.validation.data_validator.py
 """
 
@@ -69,6 +69,8 @@ results = {
                 },
             ],
         },
+        # Gaps test result example 1
+        # Follows same format as relationship test result
         {
             "type": "gaps",
             "inputs": {},

--- a/kf_lib_data_ingest/validation/reporting/table.py
+++ b/kf_lib_data_ingest/validation/reporting/table.py
@@ -156,7 +156,7 @@ class TableReportBuilder(AbstractReportBuilder):
                 formatted_locations = defaultdict(set)
                 for (typ, val), files in error["locations"].items():
                     for f in files:
-                        formatted_locations[f].add(f'`{val}`')
+                        formatted_locations[f].add(f"`{val}`")
 
                 row_dicts.append(
                     {

--- a/kf_lib_data_ingest/validation/reporting/table.py
+++ b/kf_lib_data_ingest/validation/reporting/table.py
@@ -1,0 +1,179 @@
+"""
+Table based validation report builder. Produces the following tabular files:
+
+table_reports/
+  - validation_results.tsv
+  - files_validated.tsv
+  - type_counts.tsv
+
+Unpack the validation results JSON into a tabular form where the content is
+a little bit less nested and verbose
+
+Extends kf_lib_data_ingest.validation.reporting.base.AbstractReportBuilder
+"""
+import os
+from collections import defaultdict
+
+import pandas
+
+from kf_lib_data_ingest.validation.reporting.base import AbstractReportBuilder
+
+RESULTS_FILENAME = "validation_results.tsv"
+TYPE_COUNTS_FILENAME = "type_counts.tsv"
+FILES_VALIDATED_FILENAME = "files_validated.tsv"
+
+
+class TableReportBuilder(AbstractReportBuilder):
+    def __init__(self, output_dir=None, setup_logger=False):
+        """
+        Constructor
+
+        See AbstractReportBuilder.__init__
+        """
+        super().__init__(output_dir=output_dir, setup_logger=setup_logger)
+
+    def _build(self, results):
+        """
+        Build a pandas.DataFrame from the validation results
+
+        :param results: See AbstractReportBuilder._build
+        :param type: See AbstractReportBuilder._build
+        :param title: Report title
+        :type title: str
+        """
+        dfs = []
+        # Validation results table
+        row_dicts = [
+            rd
+            for r in results["validation"]
+            for rd in self._result_dict_to_df_row(r)
+        ]
+        dfs.append(
+            (
+                pandas.DataFrame(row_dicts)[
+                    [
+                        "type",
+                        "result",
+                        "description",
+                        "errors",
+                        "locations",
+                        "details",
+                    ]
+                ],
+                RESULTS_FILENAME,
+            )
+        )
+        # Type counts table
+        dfs.append(
+            (
+                pandas.DataFrame(
+                    [
+                        {"Entity": typ, "Count": count}
+                        for typ, count in results["counts"].items()
+                    ]
+                ),
+                TYPE_COUNTS_FILENAME,
+            )
+        )
+        # Files validated
+        dfs.append(
+            (
+                pandas.DataFrame(
+                    results["files_validated"], columns={"Files Validated"}
+                ),
+                FILES_VALIDATED_FILENAME,
+            )
+        )
+
+        return dfs
+
+    def _write_report(self, dfs):
+        """
+        Write tabular validation report files to disk:
+
+            table_reports/
+              - validation_results.tsv  -> Validation test results
+              - files_validated.tsv     -> List of files validated
+              - type_counts.tsv         -> Entity counts by type
+
+        :param dfs: list of (pandas.DataFrame, filename)
+        :type dfs: list of tuples
+        """
+        output_dir = os.path.join(self.output_dir, "table_reports")
+        os.makedirs(output_dir, exist_ok=True)
+
+        for df, fn in dfs:
+            df.to_csv(os.path.join(output_dir, fn), sep="\t", index=False)
+
+        return output_dir
+
+    def _result_dict_to_df_row(self, result):
+        """
+        Unpack verbose, nested validation result dict into a simpler dict
+        suitable for a pandas.DataFrame row
+
+        :param result: See sample_validation_results.py
+        :type result: dict
+        """
+        row_dicts = []
+        # Successful tests or tests that did not run
+        if not result["errors"]:
+            row_dicts.append(
+                {
+                    "errors": None,
+                    "locations": None,
+                }
+            )
+        # -- Failed tests --
+        elif result["type"] == "count":
+            row_dicts.append(
+                {
+                    "errors": result["errors"],
+                    "locations": None,
+                }
+            )
+        elif result["type"] == "attribute":
+            for filepath, invalid_values in result["errors"].items():
+                row_dicts.append(
+                    {
+                        "errors": set(invalid_values),
+                        "locations": filepath,
+                    }
+                )
+        elif result["type"] == "relationship":
+            for error in result["errors"]:
+                # Errors
+                from_type, from_val = error["from"]
+                details = {from_val: from_type}
+                to_nodes = []
+                for to_node in error["to"]:
+                    to_type, to_val = to_node
+                    to_nodes.append(to_val)
+                    details[to_val] = to_type
+                formatted_errors = (from_val, to_nodes)
+
+                # Locations
+                formatted_locations = defaultdict(set)
+                for (typ, val), files in error["locations"].items():
+                    for f in files:
+                        formatted_locations[f].add(f'`{val}`')
+
+                row_dicts.append(
+                    {
+                        "errors": formatted_errors,
+                        "locations": dict(formatted_locations),
+                        "details": details,
+                    }
+                )
+
+        for rd in row_dicts:
+            rd.update(
+                {
+                    "type": result["type"],
+                    "description": result["description"],
+                    "result": self._result_code(result),
+                    "details": rd.get("details"),
+                }
+            )
+
+        return row_dicts

--- a/kf_lib_data_ingest/validation/reporting/table.py
+++ b/kf_lib_data_ingest/validation/reporting/table.py
@@ -26,15 +26,13 @@ FILES_VALIDATED_FILENAME = "files_validated.tsv"
 class TableReportBuilder(AbstractReportBuilder):
     def __init__(self, output_dir=None, setup_logger=False):
         """
-        Constructor
-
-        See AbstractReportBuilder.__init__
+        Constructor - see AbstractReportBuilder.__init__
         """
         super().__init__(output_dir=output_dir, setup_logger=setup_logger)
 
     def _build(self, results):
         """
-        Build a pandas.DataFrame from the validation results
+        Build a pandas.DataFrame from the list of validation test result dicts
 
         :param results: See AbstractReportBuilder._build
         :param type: See AbstractReportBuilder._build
@@ -91,10 +89,10 @@ class TableReportBuilder(AbstractReportBuilder):
         """
         Write tabular validation report files to disk:
 
-            table_reports/
-              - validation_results.tsv  -> Validation test results
-              - files_validated.tsv     -> List of files validated
-              - type_counts.tsv         -> Entity counts by type
+        table_reports/
+          - validation_results.tsv  -> Validation test results
+          - files_validated.tsv     -> List of files validated
+          - type_counts.tsv         -> Entity counts by type
 
         :param dfs: list of (pandas.DataFrame, filename)
         :type dfs: list of tuples

--- a/kf_lib_data_ingest/validation/validation.py
+++ b/kf_lib_data_ingest/validation/validation.py
@@ -10,7 +10,6 @@ from kf_lib_data_ingest.validation.data_validator import (
 from kf_lib_data_ingest.validation.reporting.table import TableReportBuilder
 from kf_lib_data_ingest.validation.reporting.markdown import (
     MarkdownReportBuilder,
-
 )
 
 VALIDATION_OUTPUT_DIR = "validation_results"
@@ -32,24 +31,6 @@ def check_results(results):
 
     :returns: whether validation passed or not
     """
-    return all([not r['errors'] for r in results['validation']])
-
-
-def check_results(results):
-    """
-    Validation passes if every test in `results` has no errors. Otherwise
-    validation fails
-
-    This method is called when `results` was read from file and you only need
-    to evaluate whether validation passed or not
-
-    :param results: Validation results. See sample_validation_results.py in
-    kf_lib_data_ingest.validation.reporting for an example
-    :type results: dict
-
-    :returns: whether validation passed or not
-    """
-
     return all([not r["errors"] for r in results["validation"]])
 
 

--- a/kf_lib_data_ingest/validation/validation.py
+++ b/kf_lib_data_ingest/validation/validation.py
@@ -66,6 +66,16 @@ class Validator(object):
         """
         Validate a set of tabular files containing a standardized set of
         columns and write validation report(s) to disk
+
+        :param filepath_list: List of paths of files to validate
+        :type filepath_list: list
+        :param include_implicit: whether to account for implied connections
+        :type include_implicit: bool
+        :param report_kwargs: Keyword arguments for each report builder
+        Forwarded to Validator._build_report
+        :type report_kwargs: dict
+
+        :returns: boolean indicating whether validation passed
         """
         try:
             # File paths to dict of DataFrames

--- a/kf_lib_data_ingest/validation/validation.py
+++ b/kf_lib_data_ingest/validation/validation.py
@@ -2,13 +2,37 @@ import os
 import sys
 import logging
 
+from kf_lib_data_ingest.common.type_safety import assert_safe_type
 from kf_lib_data_ingest.common.io import read_df, write_json
 from kf_lib_data_ingest.validation.data_validator import (
     Validator as DataValidator,
 )
+from kf_lib_data_ingest.validation.reporting.table import TableReportBuilder
+from kf_lib_data_ingest.validation.reporting.markdown import (
+    MarkdownReportBuilder,
+
+)
 
 VALIDATION_OUTPUT_DIR = "validation_results"
 RESULTS_FILENAME = "validation_results.json"
+REPORT_BUILDERS = {"tsv": TableReportBuilder, "md": MarkdownReportBuilder}
+
+
+def check_results(results):
+    """
+    Validation passes if every test in `results` has no errors. Otherwise
+    validation fails
+
+    This method is called when `results` was read from file and you only need
+    to evaluate whether validation passed or not
+
+    :param results: Validation results. See sample_validation_results.py in
+    kf_lib_data_ingest.validation.reporting for an example
+    :type results: dict
+
+    :returns: whether validation passed or not
+    """
+    return all([not r['errors'] for r in results['validation']])
 
 
 def check_results(results):
@@ -83,8 +107,7 @@ class Validator(object):
             self.logger.info(f"Wrote validation results json to: {p}")
 
             # Build and write validation reports to disk
-            # TODO - Uncomment later
-            # self._build_report(results, report_kwargs=report_kwargs)
+            self._build_report(results, report_kwargs=report_kwargs)
 
             return check_results(results)
 
@@ -94,5 +117,46 @@ class Validator(object):
             sys.exit(1)
 
     def _build_report(self, results, formats=None, report_kwargs={}):
-        # TODO - Fill in later
-        pass
+        """
+        Write validation report(s) (optionally in various formats) to disk
+        Write original validation results to disk
+
+        The `report_kwargs` is a dict of keyword argument dicts, where keys
+        are the same as keys in REPORT_BUILDERS and values are the keyword
+        arguments for a specific report builder. The builder's kwargs are
+        passed to its `build` method.
+
+        For example:
+
+        report_kwargs = {
+            'md': {'title': 'My Report'},
+            'html': {'title': 'My Report', 'other_setting': 'foo'}
+        }
+        MarkdownReportBuilder().build(**report_kwargs['md'])
+
+        :param results: validation results
+        :type results: dict
+        :param formats: iterable of format strings. See keys of REPORT_BUILDERS
+        for current list of accepted formats
+        :type formats: iterable
+        :param report_kwargs: Keyword argument dicts passed to the report
+        builder `build` methods.
+        :type report_kwargs: dict
+
+        :returns: list of report file paths
+        """
+        assert_safe_type(report_kwargs, dict)
+        paths = []
+        formats = formats or REPORT_BUILDERS.keys()
+        for f in formats:
+            if f in REPORT_BUILDERS:
+                paths.extend(
+                    REPORT_BUILDERS[f](output_dir=self.output_dir).build(
+                        results, **report_kwargs.get(f, {})
+                    )
+                )
+            else:
+                self.logger.warning(
+                    f"Validation report format `{f}` not supported"
+                )
+        return paths

--- a/kf_lib_data_ingest/validation/validation.py
+++ b/kf_lib_data_ingest/validation/validation.py
@@ -48,6 +48,7 @@ class Validator(object):
         self.output_dir = output_dir or os.path.join(
             os.getcwd(), VALIDATION_OUTPUT_DIR
         )
+        self.report_file_paths = []
         os.makedirs(self.output_dir, exist_ok=True)
 
         if init_logger:
@@ -98,7 +99,9 @@ class Validator(object):
             self.logger.info(f"Wrote validation results json to: {p}")
 
             # Build and write validation reports to disk
-            self._build_report(results, report_kwargs=report_kwargs)
+            self.report_file_paths = self._build_report(
+                results, report_kwargs=report_kwargs
+            )
 
             return check_results(results)
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -151,10 +151,10 @@ def test_build_reports(tmpdir, info_caplog):
     for rp in report_paths:
         assert os.path.isfile(rp)
         fn, ext = os.path.splitext(rp)
-        if ext == '.md':
-            with open(rp, 'r') as md_file:
+        if ext == ".md":
+            with open(rp, "r") as md_file:
                 assert md_file.read()
-        elif ext == '.tsv':
+        elif ext == ".tsv":
             df = None
             try:
                 df = read_df(rp)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -16,6 +16,8 @@ from kf_lib_data_ingest.validation.data_validator import (
     Validator as DataValidator,
 )
 from kf_lib_data_ingest.validation.default_hierarchy import DH
+from kf_lib_data_ingest.validation.validation import Validator
+from kf_lib_data_ingest.validation.reporting import sample_validation_results
 
 from conftest import TEST_DATA_DIR
 
@@ -131,3 +133,31 @@ def test_datasets(dir):
         test_hierarchy = None
     assert df_dict and reference
     verify_df_dict(df_dict, reference, test_hierarchy)
+
+
+def test_build_reports(tmpdir, info_caplog):
+    """
+    Test validation report building in kf_lib_data_ingest.validation.reporting
+    """
+    # Test normal case with sample validation results
+    path = tmpdir.mkdir("validation_results")
+    report_paths = Validator(output_dir=path)._build_report(
+        sample_validation_results.results, formats={"tsv", "md", "foobar"}
+    )
+    # Unsupported report format
+    assert "`foobar` not supported" in info_caplog.text
+
+    # Check report(s) content
+    for rp in report_paths:
+        assert os.path.isfile(rp)
+        fn, ext = os.path.splitext(rp)
+        if ext == '.md':
+            with open(rp, 'r') as md_file:
+                assert md_file.read()
+        elif ext == '.tsv':
+            df = None
+            try:
+                df = read_df(rp)
+            except Exception:
+                assert False
+            assert (df is not None) and (not df.empty)


### PR DESCRIPTION
Closes #480 

Currently outputs two types of validation reports: TSV and markdown. 

**TSV**
This isn't really a report, but 3 tables: `type_counts.tsv`,`files_validated.tsv`, `validation_results.tsv`. The `validation_results.tsv` table is a less nested, less verbose version of the original validation results coming from the graph validator. 

I added this because we were told the analysts want a tabular version of the validation results, but I think new markdown report will satisfy their needs. So we can get rid of this if we don't think its useful

**Markdown**
The markdown report is meant to be a more human friendly/readable form of the original validation results from the graph validator. The report currently looks like this:

# 📓 Data Validation Report
## 📂 Files Validated
**/Users/singhn4/Projects/pull-request-reviews/kf-lib-data-ingest/tests/data/validation/DATASET1**

| Files    |
|:---------|
| pf.csv   |
| pg.csv   |
| sfp2.csv |
| sg.csv   |
| sp.csv   |
| spf.csv  |


##  #️⃣  Counts
| Entity                              |   Count |
|:------------------------------------|--------:|
| BIOSPECIMEN.ID                      |      12 |
| PARTICIPANT.ID                      |      10 |
| FAMILY.ID                           |       7 |
| GENOMIC_FILE.URL_LIST               |       5 |
| BIOSPECIMEN.SHIPMENT_ORIGIN         |       0 |
| SEQUENCING.PLATFORM                 |       0 |
| SEQUENCING.PAIRED_END               |       0 |
| SEQUENCING.STRATEGY                 |       0 |
| SEQUENCING.LIBRARY_NAME             |       0 |
| GENOMIC_FILE.REFERENCE_GENOME       |       0 |
| GENOMIC_FILE.HARMONIZED             |       0 |
| SEQUENCING.ID                       |       0 |
| BIOSPECIMEN.SAMPLE_PROCUREMENT      |       0 |
| BIOSPECIMEN.VOLUME_UL               |       0 |
| BIOSPECIMEN.CONCENTRATION_MG_PER_ML |       0 |
| BIOSPECIMEN.SHIPMENT_DATE           |       0 |
| BIOSPECIMEN.SPATIAL_DESCRIPTOR      |       0 |
| BIOSPECIMEN.EVENT_AGE_DAYS          |       0 |
| BIOSPECIMEN.TUMOR_DESCRIPTOR        |       0 |
| BIOSPECIMEN.ANATOMY_SITE            |       0 |
| BIOSPECIMEN.TISSUE_TYPE             |       0 |
| BIOSPECIMEN.COMPOSITION             |       0 |
| BIOSPECIMEN.ANALYTE                 |       0 |
| GENOMIC_FILE.ID                     |       0 |
| PARTICIPANT.ENROLLMENT_AGE_DAYS     |       0 |
| PARTICIPANT.SPECIES                 |       0 |
| PARTICIPANT.RACE                    |       0 |
| PARTICIPANT.ETHNICITY               |       0 |
| PARTICIPANT.GENDER                  |       0 |
| SEQUENCING.INSTRUMENT               |       0 |

## 🚦 Relationship Tests
### `Fail: 6` `Success: 16` `Did Not Run: 35`

#### ❌ Each FAMILY.ID links to at least 1 PARTICIPANT.ID

| Errors                                           |
|:-------------------------------------------------|
| `FAMILY.ID.F12` is linked to  0 `PARTICIPANT.ID` |

| Location   | Values                                                       |
|:-----------|:-------------------------------------------------------------|
| pf.csv     | This file contains all errors in the **Errors** table above. |

#### ❌ Each BIOSPECIMEN.ID links to exactly 1 PARTICIPANT.ID

| Errors                                               |
|:-----------------------------------------------------|
| `BIOSPECIMEN.ID.S2` is linked to  ['`P2`', '`P1`']   |
| `BIOSPECIMEN.ID.S8` is linked to  0 `PARTICIPANT.ID` |

| Location   | Values                                                       |
|:-----------|:-------------------------------------------------------------|
| sfp2.csv   | This file contains all errors in the **Errors** table above. |
| spf.csv    | `P1`,`S8`,``S2``                                             |

#### ❌ Each PARTICIPANT.ID links to at least 1 BIOSPECIMEN.ID

| Errors                                                |
|:------------------------------------------------------|
| `PARTICIPANT.ID.P13` is linked to  0 `BIOSPECIMEN.ID` |
| `PARTICIPANT.ID.P11` is linked to  0 `BIOSPECIMEN.ID` |

| Location   | Values                                                       |
|:-----------|:-------------------------------------------------------------|
| pf.csv     | This file contains all errors in the **Errors** table above. |

#### ❌ Each BIOSPECIMEN.ID links to at least 1 GENOMIC_FILE.ID

| Errors                                                 |
|:-------------------------------------------------------|
| `BIOSPECIMEN.ID.NA` is linked to  0 `GENOMIC_FILE.ID`  |
| `BIOSPECIMEN.ID.S7` is linked to  0 `GENOMIC_FILE.ID`  |
| `BIOSPECIMEN.ID.S2` is linked to  0 `GENOMIC_FILE.ID`  |
| `BIOSPECIMEN.ID.S4` is linked to  0 `GENOMIC_FILE.ID`  |
| `BIOSPECIMEN.ID.S6` is linked to  0 `GENOMIC_FILE.ID`  |
| `BIOSPECIMEN.ID.S8` is linked to  0 `GENOMIC_FILE.ID`  |
| `BIOSPECIMEN.ID.S11` is linked to  0 `GENOMIC_FILE.ID` |
| `BIOSPECIMEN.ID.S9` is linked to  0 `GENOMIC_FILE.ID`  |
| `BIOSPECIMEN.ID.S10` is linked to  0 `GENOMIC_FILE.ID` |
| `BIOSPECIMEN.ID.S3` is linked to  0 `GENOMIC_FILE.ID`  |
| `BIOSPECIMEN.ID.S1` is linked to  0 `GENOMIC_FILE.ID`  |
| `BIOSPECIMEN.ID.S5` is linked to  0 `GENOMIC_FILE.ID`  |

| Location   | Values                                               |
|:-----------|:-----------------------------------------------------|
| sfp2.csv   | `NA`,`S2`,`S7`                                       |
| sg.csv     | `S10`,``S7``                                         |
| sp.csv     | `S11`,``S10``,```S7```                               |
| spf.csv    | `S1`,`S3`,`S4`,`S5`,`S6`,`S8`,`S9`,``S2``,````S7```` |

#### ❌ Each BIOSPECIMEN.ID links to exactly 1 BIOSPECIMEN.ANALYTE

| Errors                                                     |
|:-----------------------------------------------------------|
| `BIOSPECIMEN.ID.NA` is linked to  0 `BIOSPECIMEN.ANALYTE`  |
| `BIOSPECIMEN.ID.S7` is linked to  0 `BIOSPECIMEN.ANALYTE`  |
| `BIOSPECIMEN.ID.S2` is linked to  0 `BIOSPECIMEN.ANALYTE`  |
| `BIOSPECIMEN.ID.S4` is linked to  0 `BIOSPECIMEN.ANALYTE`  |
| `BIOSPECIMEN.ID.S6` is linked to  0 `BIOSPECIMEN.ANALYTE`  |
| `BIOSPECIMEN.ID.S8` is linked to  0 `BIOSPECIMEN.ANALYTE`  |
| `BIOSPECIMEN.ID.S11` is linked to  0 `BIOSPECIMEN.ANALYTE` |
| `BIOSPECIMEN.ID.S9` is linked to  0 `BIOSPECIMEN.ANALYTE`  |
| `BIOSPECIMEN.ID.S10` is linked to  0 `BIOSPECIMEN.ANALYTE` |
| `BIOSPECIMEN.ID.S3` is linked to  0 `BIOSPECIMEN.ANALYTE`  |
| `BIOSPECIMEN.ID.S1` is linked to  0 `BIOSPECIMEN.ANALYTE`  |
| `BIOSPECIMEN.ID.S5` is linked to  0 `BIOSPECIMEN.ANALYTE`  |

| Location   | Values                                               |
|:-----------|:-----------------------------------------------------|
| sfp2.csv   | `NA`,`S2`,`S7`                                       |
| sg.csv     | `S10`,``S7``                                         |
| sp.csv     | `S11`,``S10``,```S7```                               |
| spf.csv    | `S1`,`S3`,`S4`,`S5`,`S6`,`S8`,`S9`,``S2``,````S7```` |

#### ❌ Each GENOMIC_FILE.URL_LIST links to exactly 1 GENOMIC_FILE.ID

| Errors                                                                    |
|:--------------------------------------------------------------------------|
| `GENOMIC_FILE.URL_LIST.['foo/s10.txt']` is linked to  0 `GENOMIC_FILE.ID` |
| `GENOMIC_FILE.URL_LIST.['foo/s5.txt']` is linked to  0 `GENOMIC_FILE.ID`  |
| `GENOMIC_FILE.URL_LIST.['foo/s7.txt']` is linked to  0 `GENOMIC_FILE.ID`  |
| `GENOMIC_FILE.URL_LIST.['foo/s11.txt']` is linked to  0 `GENOMIC_FILE.ID` |
| `GENOMIC_FILE.URL_LIST.['foo/s9.txt']` is linked to  0 `GENOMIC_FILE.ID`  |

| Location   | Values                                              |
|:-----------|:----------------------------------------------------|
| pg.csv     | `['foo/s11.txt']`,`['foo/s5.txt']`,`['foo/s9.txt']` |
| sg.csv     | `['foo/s10.txt']`,`['foo/s7.txt']`                  |

#### ✅ Each PARTICIPANT.ID links to at most 1 PARTICIPANT.GENDER


#### ✅ Each PARTICIPANT.ID links to at most 1 PARTICIPANT.ETHNICITY


#### ✅ Each PARTICIPANT.ID links to at most 1 PARTICIPANT.RACE


#### ✅ Each PARTICIPANT.ID links to at most 1 PARTICIPANT.SPECIES


#### ✅ Each PARTICIPANT.ID links to at most 1 PARTICIPANT.ENROLLMENT_AGE_DAYS


#### ✅ Each BIOSPECIMEN.ID links to at most 1 BIOSPECIMEN.COMPOSITION


#### ✅ Each BIOSPECIMEN.ID links to at most 1 BIOSPECIMEN.TISSUE_TYPE


#### ✅ Each BIOSPECIMEN.ID links to at most 1 BIOSPECIMEN.ANATOMY_SITE


#### ✅ Each BIOSPECIMEN.ID links to at most 1 BIOSPECIMEN.TUMOR_DESCRIPTOR


#### ✅ Each BIOSPECIMEN.ID links to at most 1 BIOSPECIMEN.EVENT_AGE_DAYS


#### ✅ Each BIOSPECIMEN.ID links to at most 1 BIOSPECIMEN.SPATIAL_DESCRIPTOR


#### ✅ Each BIOSPECIMEN.ID links to at most 1 BIOSPECIMEN.SHIPMENT_ORIGIN


#### ✅ Each BIOSPECIMEN.ID links to at most 1 BIOSPECIMEN.SHIPMENT_DATE


#### ✅ Each BIOSPECIMEN.ID links to at most 1 BIOSPECIMEN.CONCENTRATION_MG_PER_ML


#### ✅ Each BIOSPECIMEN.ID links to at most 1 BIOSPECIMEN.VOLUME_UL


#### ✅ Each BIOSPECIMEN.ID links to at most 1 BIOSPECIMEN.SAMPLE_PROCUREMENT


🔘 Each GENOMIC_FILE.ID links to exactly 1 SEQUENCING.ID


🔘 Each SEQUENCING.ID links to at least 1 GENOMIC_FILE.ID


🔘 Each GENOMIC_FILE.ID links to exactly 1 BIOSPECIMEN.ID


🔘 Each PARTICIPANT.GENDER links to at least 1 PARTICIPANT.ID


🔘 Each PARTICIPANT.ETHNICITY links to at least 1 PARTICIPANT.ID


🔘 Each PARTICIPANT.RACE links to at least 1 PARTICIPANT.ID


🔘 Each PARTICIPANT.SPECIES links to at least 1 PARTICIPANT.ID


🔘 Each PARTICIPANT.ENROLLMENT_AGE_DAYS links to at least 1 PARTICIPANT.ID


🔘 Each BIOSPECIMEN.ANALYTE links to at least 1 BIOSPECIMEN.ID


🔘 Each BIOSPECIMEN.COMPOSITION links to at least 1 BIOSPECIMEN.ID


🔘 Each BIOSPECIMEN.TISSUE_TYPE links to at least 1 BIOSPECIMEN.ID


🔘 Each BIOSPECIMEN.ANATOMY_SITE links to at least 1 BIOSPECIMEN.ID


🔘 Each BIOSPECIMEN.TUMOR_DESCRIPTOR links to at least 1 BIOSPECIMEN.ID


🔘 Each BIOSPECIMEN.EVENT_AGE_DAYS links to at least 1 BIOSPECIMEN.ID


🔘 Each BIOSPECIMEN.SPATIAL_DESCRIPTOR links to at least 1 BIOSPECIMEN.ID


🔘 Each BIOSPECIMEN.SHIPMENT_ORIGIN links to at least 1 BIOSPECIMEN.ID


🔘 Each BIOSPECIMEN.SHIPMENT_DATE links to at least 1 BIOSPECIMEN.ID


🔘 Each BIOSPECIMEN.CONCENTRATION_MG_PER_ML links to at least 1 BIOSPECIMEN.ID


🔘 Each BIOSPECIMEN.VOLUME_UL links to at least 1 BIOSPECIMEN.ID


🔘 Each BIOSPECIMEN.SAMPLE_PROCUREMENT links to at least 1 BIOSPECIMEN.ID


🔘 Each GENOMIC_FILE.HARMONIZED links to at least 1 GENOMIC_FILE.ID


🔘 Each GENOMIC_FILE.ID links to exactly 1 GENOMIC_FILE.HARMONIZED


🔘 Each GENOMIC_FILE.REFERENCE_GENOME links to at least 1 GENOMIC_FILE.ID


🔘 Each GENOMIC_FILE.ID links to exactly 1 GENOMIC_FILE.REFERENCE_GENOME


🔘 Each GENOMIC_FILE.ID links to exactly 1 GENOMIC_FILE.URL_LIST


🔘 Each SEQUENCING.LIBRARY_NAME links to exactly 1 SEQUENCING.ID


🔘 Each SEQUENCING.ID links to at most 1 SEQUENCING.LIBRARY_NAME


🔘 Each SEQUENCING.STRATEGY links to at least 1 SEQUENCING.ID


🔘 Each SEQUENCING.ID links to exactly 1 SEQUENCING.STRATEGY


🔘 Each SEQUENCING.PAIRED_END links to at least 1 SEQUENCING.ID


🔘 Each SEQUENCING.ID links to exactly 1 SEQUENCING.PAIRED_END


🔘 Each SEQUENCING.PLATFORM links to at least 1 SEQUENCING.ID


🔘 Each SEQUENCING.ID links to at most 1 SEQUENCING.PLATFORM


🔘 Each SEQUENCING.INSTRUMENT links to at least 1 SEQUENCING.ID


🔘 Each SEQUENCING.ID links to at most 1 SEQUENCING.INSTRUMENT


## 🚦 Gap Tests
### `Fail: 1` `Success: 0` `Did Not Run: 0`

#### ❌ All resolved links are hierarchically direct

| Errors                                                                         |
|:-------------------------------------------------------------------------------|
| `GENOMIC_FILE.URL_LIST.['foo/s11.txt']` is linked to  ['`BIOSPECIMEN.ID.S11`'] |
| `GENOMIC_FILE.URL_LIST.['foo/s10.txt']` is linked to  ['`BIOSPECIMEN.ID.S10`'] |
| `GENOMIC_FILE.URL_LIST.['foo/s5.txt']` is linked to  ['`BIOSPECIMEN.ID.S5`']   |
| `GENOMIC_FILE.URL_LIST.['foo/s7.txt']` is linked to  ['`BIOSPECIMEN.ID.S7`']   |
| `GENOMIC_FILE.URL_LIST.['foo/s9.txt']` is linked to  ['`BIOSPECIMEN.ID.S9`']   |

| Location   | Values                                                                                                                                   |
|:-----------|:-----------------------------------------------------------------------------------------------------------------------------------------|
| pg.csv     | `GENOMIC_FILE.URL_LIST.['foo/s11.txt']`,`GENOMIC_FILE.URL_LIST.['foo/s5.txt']`,`GENOMIC_FILE.URL_LIST.['foo/s9.txt']`                    |
| sfp2.csv   | `BIOSPECIMEN.ID.S7`                                                                                                                      |
| sg.csv     | `BIOSPECIMEN.ID.S10`,`BIOSPECIMEN.ID.`BIOSPECIMEN.ID.S7``,`GENOMIC_FILE.URL_LIST.['foo/s10.txt']`,`GENOMIC_FILE.URL_LIST.['foo/s7.txt']` |
| sp.csv     | `BIOSPECIMEN.ID.S11`,`BIOSPECIMEN.ID.`BIOSPECIMEN.ID.S10``,`BIOSPECIMEN.ID.`BIOSPECIMEN.ID.`BIOSPECIMEN.ID.S7```                         |
| spf.csv    | `BIOSPECIMEN.ID.S5`,`BIOSPECIMEN.ID.S9`,`BIOSPECIMEN.ID.`BIOSPECIMEN.ID.`BIOSPECIMEN.ID.`BIOSPECIMEN.ID.S7````                           |

## 🚦 Attribute Value Tests
### `Fail: 0` `Success: 0` `Did Not Run: 36`

🔘 PARTICIPANT.RACE must be one of ['American Indian or Alaska Native', 'Asian', 'Black or African American', 'More Than One Race', 'Native Hawaiian or Other Pacific Islander', 'Other', 'White'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 PARTICIPANT.ENROLLMENT_AGE_DAYS must be a number x such that 0 <= x <= 32872.


🔘 PARTICIPANT.ETHNICITY must be one of ['Hispanic or Latino', 'Not Hispanic or Latino'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 PARTICIPANT.GENDER must be one of ['Female', 'Male', 'Other'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 PARTICIPANT.SPECIES must be one of ['Canis lupus familiaris', 'Homo Sapiens'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 PARTICIPANT.CONSENT_TYPE must be one of ['DS-CHD', 'DS-CHD-IRB', 'DS-OBD-MDS', 'DS-OBDR-MDS', 'DS-OC-PUB-MDS', 'GRU', 'HMB-IRB', 'HMB-MDS'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 BIOSPECIMEN.EVENT_AGE_DAYS must be a number x such that 0 <= x <= 32872.


🔘 BIOSPECIMEN.ANALYTE must be one of ['DNA', 'Other', 'RNA', 'Virtual'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 BIOSPECIMEN.CONCENTRATION_MG_PER_ML must be a number > 0.


🔘 BIOSPECIMEN.SAMPLE_PROCUREMENT must be one of ['Autopsy', 'Biopsy', 'Blood Draw', 'Gross Total Resection', 'Other', 'Subtotal Resection'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 BIOSPECIMEN.SHIPMENT_DATE must be a valid representation of a Date or Datetime object.


🔘 BIOSPECIMEN.VOLUME_UL must be a number > 0.


🔘 DIAGNOSIS.EVENT_AGE_DAYS must be a number > 0.


🔘 DIAGNOSIS.CATEGORY must be one of ['Cancer', 'Other', 'Structural Birth Defect'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 GENOMIC_FILE.AVAILABILITY must be one of ['Cold Storage', 'Immediate Download'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 GENOMIC_FILE.DATA_TYPE must be one of ['Aligned Reads', 'Aligned Reads Index', 'Expression', 'Gene Expression', 'Gene Fusions', 'Histology Images', 'Isoform Expression', 'Operation Reports', 'Other', 'Pathology Reports', 'Radiology Images', 'Radiology Reports', 'Simple Nucleotide Variations', 'Somatic Copy Number Variations', 'Somatic Structural Variations', 'Unaligned Reads', 'Variant Calls', 'Variant Calls Index', 'gVCF', 'gVCF Index'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 GENOMIC_FILE.SIZE must be a number >= 0.


🔘 OUTCOME.EVENT_AGE_DAYS must be a number x such that 0 <= x <= 32872.


🔘 OUTCOME.DISEASE_RELATED must be one of ['No', 'Yes'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 OUTCOME.VITAL_STATUS must be one of ['Alive', 'Deceased'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 PHENOTYPE.EVENT_AGE_DAYS must be a number x such that 0 <= x <= 32872.


🔘 PHENOTYPE.OBSERVED must be one of ['Negative', 'Positive'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 READ_GROUP.PAIRED_END must be one of ['1', '2'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 READ_GROUP.LANE_NUMBER must be a number > 0.


🔘 READ_GROUP.QUALITY_SCALE must be one of ['Illumina13', 'Illumina15', 'Illumina18', 'Sanger', 'Solexa'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 SEQUENCING.DATE must be a valid representation of a Date or Datetime object.


🔘 SEQUENCING.STRATEGY must be one of ['Linked-Read WGS (10x Chromium)', 'Other', 'RNA-Seq', 'Targeted Sequencing', 'WGS', 'WXS', 'miRNA-Seq'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 SEQUENCING.LIBRARY_STRAND must be one of ['First Stranded', 'Other', 'Second Stranded', 'Unstranded'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 SEQUENCING.MAX_INSERT_SIZE must be a number > 0.


🔘 SEQUENCING.MEAN_DEPTH must be a number > 0.


🔘 SEQUENCING.MEAN_INSERT_SIZE must be a number > 0.


🔘 SEQUENCING.MEAN_READ_LENGTH must be a number > 0.


🔘 SEQUENCING.PAIRED_END must be one of ['False', 'True'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 SEQUENCING.PLATFORM must be one of ['Complete Genomics', 'Illumina', 'Ion Torrent', 'LS454', 'Other', 'PacBio', 'SOLiD'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


🔘 SEQUENCING.TOTAL_READS must be a number > 0.


🔘 STUDY_FILE.AVAILABILITY must be one of ['Cold Storage', 'Immediate Download'] or ['Not Allowed To Collect', 'Not Applicable', 'Not Available', 'Not Reported', 'Reported Unknown']


## 🚦 Count Tests
### `Fail: 0` `Success: 0` `Did Not Run: 0`