### PR TITLE
✨add hmb-npu to constants.CONSENT_TYPE

### DIFF
--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -303,6 +303,11 @@ class CONSENT_TYPE:
     # Disease specific Cardiac Heart Defect
     DS_CHD = "DS-CHD"
     # Disease specific Cardiac Heart Defect
+    HMB_NPU = "HMB-NPU"
+    # Health/Medical/Biomedical (NPU) (HMB-NPU) - Use of this data is
+    # limited to health/medical/biomedical purposes, does not include the
+    # study of population origins or ancestry. Use of the data is limited to
+    # not-for-profit organizations.
     GRU = "GRU"
     # General Research Use
 


### PR DESCRIPTION
adds consent group for health/medical/biomedical for not-for-profit organizations only.Information for this consent group can be found [here](https://osp.od.nih.gov/wp-content/uploads/standard_data_use_limitations.pdf). found in one of the cohorts of `SD_Z6MWD3H0` 