### PR TITLE
🐛 Fake-cache target IDs in dry run mode 

### DIFF
--- a/kf_lib_data_ingest/etl/load/load_v2.py
+++ b/kf_lib_data_ingest/etl/load/load_v2.py
@@ -58,7 +58,10 @@ class LoadStage(LoadV1):
                 tic = tic_list[0]
                 if tic and (tic != constants.COMMON.NOT_REPORTED):
                     self._store_target_id_for_key(
-                        entity_class.class_name, str(key_components), tic
+                        entity_class.class_name,
+                        str(key_components),
+                        tic,
+                        self.dry_run,
                     )
                     return tic
         except Exception:

--- a/tests/test_load_stage.py
+++ b/tests/test_load_stage.py
@@ -63,14 +63,18 @@ def test_uid_cache(tmpdir):
 
     assert os.path.exists(a1.uid_cache_filepath)
 
-    a1._store_target_id_for_key("entity_type", "entity_unique_key", "target_id")
+    a1._store_target_id_for_key(
+        "entity_type", "entity_unique_key", "target_id", True
+    )
     assert (
         a1._get_target_id_from_key("entity_type", "entity_unique_key")
         == "target_id"
     )
 
     assert os.path.exists(a2.uid_cache_filepath)
-    a2._store_target_id_for_key("entity_type", "entity_unique_key", "target_id")
+    a2._store_target_id_for_key(
+        "entity_type", "entity_unique_key", "target_id", True
+    )
     assert (
         a2._get_target_id_from_key("entity_type", "entity_unique_key")
         == "target_id"
@@ -101,12 +105,16 @@ def test_uid_cache(tmpdir):
     assert os.path.exists(b1.uid_cache_filepath)
     assert os.path.exists(b2.uid_cache_filepath)
 
-    b1._store_target_id_for_key("entity type", "entity unique key", "target_id")
+    b1._store_target_id_for_key(
+        "entity type", "entity unique key", "target_id", True
+    )
     assert (
         b1._get_target_id_from_key("entity type", "entity unique key")
         == "target_id"
     )
-    b2._store_target_id_for_key("entity type", "entity_unique_key", "target id")
+    b2._store_target_id_for_key(
+        "entity type", "entity_unique_key", "target id", True
+    )
     assert (
         b2._get_target_id_from_key("entity type", "entity_unique_key")
         == "target id"


### PR DESCRIPTION
Needed for dry-loading relationship entities, because otherwise their
primary components can't be built.

closes #530 