### PR TITLE
✨ Convert family relations to P1+P2+rel

### DIFF
--- a/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
+++ b/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
@@ -9,6 +9,7 @@ See etl.configuration.target_api_config docstring for more details on the
 requirements for format and content.
 """
 from d3b_utils.requests_retry import Session
+from pandas import DataFrame
 from kf_lib_data_ingest.common import constants
 from kf_lib_data_ingest.common.concept_schema import CONCEPT
 from kf_lib_data_ingest.common.misc import (
@@ -550,14 +551,58 @@ class FamilyRelationship:
     service_id_fields = {"kf_id", "participant1_id", "participant2_id"}
 
     @classmethod
+    def transform_records_list(cls, records_list):
+        """Convert PID+REL_TO_PROBAND into P1+REL_1_TO_2+P2"""
+        rdf = DataFrame(records_list)
+        if (
+            (CONCEPT.FAMILY_RELATIONSHIP.PERSON1.ID not in rdf)
+            and (CONCEPT.FAMILY_RELATIONSHIP.PERSON2.ID not in rdf)
+            and (CONCEPT.FAMILY_RELATIONSHIP.RELATION_FROM_1_TO_2 not in rdf)
+            and (CONCEPT.PARTICIPANT.RELATIONSHIP_TO_PROBAND in rdf)
+        ):
+            relations = rdf[
+                rdf.columns.intersection(
+                    {
+                        CONCEPT.STUDY.TARGET_SERVICE_ID,
+                        CONCEPT.FAMILY.ID,
+                        CONCEPT.PARTICIPANT.ID,
+                        CONCEPT.PARTICIPANT.RELATIONSHIP_TO_PROBAND,
+                        CONCEPT.FAMILY_RELATIONSHIP.VISIBLE,
+                    }
+                )
+            ].drop_duplicates()
+
+            side1 = relations[
+                relations[CONCEPT.PARTICIPANT.RELATIONSHIP_TO_PROBAND]
+                != constants.RELATIONSHIP.PROBAND
+            ].rename(
+                columns={
+                    CONCEPT.PARTICIPANT.ID: CONCEPT.FAMILY_RELATIONSHIP.PERSON1.ID,
+                    CONCEPT.PARTICIPANT.RELATIONSHIP_TO_PROBAND: CONCEPT.FAMILY_RELATIONSHIP.RELATION_FROM_1_TO_2,
+                }
+            )
+            side2 = relations[
+                relations[CONCEPT.PARTICIPANT.RELATIONSHIP_TO_PROBAND]
+                == constants.RELATIONSHIP.PROBAND
+            ][[CONCEPT.FAMILY.ID, CONCEPT.PARTICIPANT.ID]].rename(
+                columns={
+                    CONCEPT.PARTICIPANT.ID: CONCEPT.FAMILY_RELATIONSHIP.PERSON2.ID,
+                }
+            )
+            return side1.merge(side2).to_dict("records")
+
+    @classmethod
     def get_key_components(cls, record, get_target_id_from_record):
         return {
             "participant1_id": not_none(
                 get_target_id_from_record(
                     Participant,
                     {
+                        CONCEPT.STUDY.TARGET_SERVICE_ID: record[
+                            CONCEPT.STUDY.TARGET_SERVICE_ID
+                        ],
                         CONCEPT.PARTICIPANT.ID: record[
-                            CONCEPT.FAMILY_RELATIONSHIP.PERSON1
+                            CONCEPT.FAMILY_RELATIONSHIP.PERSON1.ID
                         ],
                     },
                 )
@@ -566,8 +611,11 @@ class FamilyRelationship:
                 get_target_id_from_record(
                     Participant,
                     {
+                        CONCEPT.STUDY.TARGET_SERVICE_ID: record[
+                            CONCEPT.STUDY.TARGET_SERVICE_ID
+                        ],
                         CONCEPT.PARTICIPANT.ID: record[
-                            CONCEPT.FAMILY_RELATIONSHIP.PERSON2
+                            CONCEPT.FAMILY_RELATIONSHIP.PERSON2.ID
                         ],
                     },
                 )


### PR DESCRIPTION
We have two formats for family relationship. We often get PID+relationship_to_proband, but we need P1+P2+relationship.