### PR TITLE
💬 Add maf format to constants

### DIFF
--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -114,6 +114,7 @@ class GENOMIC_FILE:
         TBI = "tbi"
         VCF = "vcf"
         HTML = "html"
+        MAF = "maf"
 
 
 class READ_GROUP:


### PR DESCRIPTION
adds maf file format. According to @bmennis, maf files are from consensus calling. The appropriate data type for maf files is `constants.GENOMIC_FILE.DATA_TYPE.ANNOTATED_SOMATIC_MUTATIONS`