### PR TITLE
🐛 Ensure integers fit into allocated bits

### DIFF
--- a/kf_lib_data_ingest/network/utils.py
+++ b/kf_lib_data_ingest/network/utils.py
@@ -54,7 +54,7 @@ def http_get_file(url, dest_obj, **kwargs):
             success_msg += f" with original file name {filename}"
         else:
             # Header did not provide filename
-            logging.warning(
+            logger.warning(
                 f"{url} returned unhelpful or missing "
                 "Content-Disposition header "
                 f"{content_disposition}. "


### PR DESCRIPTION
This chooses to null ones that are too big instead of assigning the wrong value.