### PR TITLE
✨ Add consent_type and dbgap_consent_code to BS

### DIFF
--- a/kf_lib_data_ingest/common/concept_schema.py
+++ b/kf_lib_data_ingest/common/concept_schema.py
@@ -143,6 +143,8 @@ class CONCEPT:
         CONCENTRATION_MG_PER_ML = None
         VOLUME_UL = None
         SAMPLE_PROCUREMENT = None
+        DBGAP_STYLE_CONSENT_CODE = None
+        CONSENT_SHORT_NAME = None
 
     class GENOMIC_FILE(PropertyMixin, FileMixin):
         HARMONIZED = None

--- a/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
+++ b/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
@@ -425,6 +425,10 @@ class Biospecimen:
             "method_of_sample_procurement": record.get(
                 CONCEPT.BIOSPECIMEN.SAMPLE_PROCUREMENT
             ),
+            "dbgap_consent_code": record.get(
+                CONCEPT.BIOSPECIMEN.DBGAP_STYLE_CONSENT_CODE
+            ),
+            "consent_type": record.get(CONCEPT.BIOSPECIMEN.CONSENT_SHORT_NAME),
         }
         return {
             **cls.get_key_components(record, get_target_id_from_record),


### PR DESCRIPTION
the kids first api has consent type and dbgap consent code as attributes of biospecimen. although these values are assigned elsewhere (see https://github.com/kids-first/kf-update-dbgap-consent) for non-dbgap studies or for studies where dbgap has not released the data, these values can only be set in standalone scripts. adding these two items to the biospecimen concept allows these to be added during ingest.