### PR TITLE
🐛 Don't error on relation external_id without key fields

### DIFF
--- a/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
+++ b/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
@@ -44,16 +44,19 @@ def not_none(val):
 
 
 def external_id(cls_list, record, get_target_id_from_record):
-    out = []
-    for cls in cls_list:
-        cls_key_dict = cls.get_key_components(
-            record, get_target_id_from_record
-        ).copy()
-        for key in ["study_id", "sequencing_center_id"]:
-            cls_key_dict.pop(key, None)
-        out.extend([str(v) for v in cls_key_dict.values()])
-
-    return DELIMITER.join(out) or None
+    try:
+        out = []
+        for cls in cls_list:
+            cls_key_dict = cls.get_key_components(
+                record, get_target_id_from_record
+            ).copy()
+            for key in ["study_id", "sequencing_center_id"]:
+                cls_key_dict.pop(key, None)
+            out.extend([str(v) for v in cls_key_dict.values()])
+    except (KeyError, ValueError):
+        return None
+    else:
+        return DELIMITER.join(out) or None
 
 
 class Investigator:

--- a/tests/data/kfid_study/data/clinical.tsv
+++ b/tests/data/kfid_study/data/clinical.tsv
@@ -1,0 +1,3 @@
+BS_external_aliquot_id,BS_kfid,GF_external_id
+,BS_12345678,blah1
+BS1,BS_12345679,blah2

--- a/tests/data/kfid_study/extract_configs/extract_config.py
+++ b/tests/data/kfid_study/extract_configs/extract_config.py
@@ -1,0 +1,18 @@
+"""
+Auto-generated extract config module.
+
+See documentation at
+https://kids-first.github.io/kf-lib-data-ingest/tutorial/extract.html for
+information on writing extract config files.
+"""
+
+from kf_lib_data_ingest.etl.extract.operations import keep_map
+from kf_lib_data_ingest.common.concept_schema import CONCEPT
+
+source_data_url = "file://../data/clinical.tsv"
+
+operations = [
+    keep_map(in_col="BS_kfid", out_col=CONCEPT.BIOSPECIMEN.TARGET_SERVICE_ID),
+    keep_map(in_col="BS_external_aliquot_id", out_col=CONCEPT.BIOSPECIMEN.ID),
+    keep_map(in_col="GF_external_id", out_col=CONCEPT.GENOMIC_FILE.ID),
+]

--- a/tests/data/kfid_study/ingest_package_config.py
+++ b/tests/data/kfid_study/ingest_package_config.py
@@ -1,0 +1,13 @@
+""" Dataset Ingest Config """
+# The list of entities that will be loaded into the target service
+target_service_entities = [
+    "genomic_file",
+    "biospecimen_genomic_file",
+]
+
+# All paths are relative to the directory this file is in
+extract_config_dir = "extract_configs"
+
+transform_function_path = "transform_module.py"
+
+project = "SD_ME0WME0W"

--- a/tests/data/kfid_study/transform_module.py
+++ b/tests/data/kfid_study/transform_module.py
@@ -1,0 +1,14 @@
+"""
+Auto-generated transform module
+
+Replace the contents of transform_function with your own code
+
+See documentation at
+https://kids-first.github.io/kf-lib-data-ingest/ for information on
+implementing transform_function.
+"""
+from kf_lib_data_ingest.config import DEFAULT_KEY
+
+
+def transform_function(mapped_df_dict):
+    return {DEFAULT_KEY: mapped_df_dict["extract_config.py"]}

--- a/tests/test_kidsfirst_api_plugin.py
+++ b/tests/test_kidsfirst_api_plugin.py
@@ -1,0 +1,30 @@
+import json
+from os.path import join
+
+from click.testing import CliRunner
+from kf_lib_data_ingest.app import cli
+from kf_lib_data_ingest.target_api_plugins.kids_first_dataservice import (
+    DELIMITER,
+)
+
+from conftest import TEST_DATA_DIR, delete_dir
+
+
+def test_external_id_whole_ingest():
+    # Make sure that the external_id function combines available key components
+    # and doesn't error if referencing target service IDs directly. This test
+    # actually runs an entire ingest and looks at what would get sent.
+    runner = CliRunner()
+    study_dir = join(TEST_DATA_DIR, "kfid_study")
+    output_dir = join(study_dir, "output")
+    delete_dir(output_dir)
+    runner.invoke(cli.test, study_dir)
+    with open(join(output_dir, "LoadStage", "SentMessages.json")) as sm:
+        data = json.load(sm)
+    gfs = [e for e in data if e["type"] == "genomic_file"]
+    bsgfs = [e for e in data if e["type"] == "biospecimen_genomic_file"]
+    assert gfs[0]["body"]["external_id"] == "blah1"
+    assert gfs[1]["body"]["external_id"] == "blah2"
+    assert bsgfs[0]["body"]["external_id"] is None
+    assert bsgfs[1]["body"]["external_id"] == f"BS1{DELIMITER}blah2"
+    delete_dir(output_dir)


### PR DESCRIPTION
If the record is missing requisite key fields for the two related
sub-entities in a relation entity (BSGF, etc), just skip populating the
external_id field instead of raising an exception.