### PR TITLE
✨ Add Fly and 🐭 

### DIFF
--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -570,8 +570,10 @@ class ETHNICITY:
 
 
 class SPECIES:
-    HUMAN = "Homo Sapiens"
     DOG = "Canis lupus familiaris"
+    FLY = "Drosophila melanogaster"
+    HUMAN = "Homo Sapiens"
+    MOUSE = "Mus musculus"
 
 
 class PHENOTYPE:

--- a/kf_lib_data_ingest/etl/configuration/base_config.py
+++ b/kf_lib_data_ingest/etl/configuration/base_config.py
@@ -25,7 +25,7 @@ class AbstractConfig(ABC):
             ) from e
 
     def __getattr__(self, attr):
-        """ Forward attributes from self.contents """
+        """Forward attributes from self.contents"""
         try:
             try:
                 return self.contents[attr]
@@ -36,12 +36,12 @@ class AbstractConfig(ABC):
 
     @abstractmethod
     def _read_file(self, filepath):
-        """ Should raise a FileNotFoundError exception if file not exists """
+        """Should raise a FileNotFoundError exception if file not exists"""
         pass
 
     @abstractmethod
     def _validate(self, *args, **kwargs):
-        """ Should raise appropriate exception on failed validation """
+        """Should raise appropriate exception on failed validation"""
         pass
 
 


### PR DESCRIPTION
This PR adds `'Drosophila melanogaster'` (fruit fly) and `'Mus musculus'` (house mouse) to the species enum according to kids-first/kf-api-dataservice#572.