### PR TITLE
🐛 Fix Homo sapiens casing

### DIFF
--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -572,7 +572,7 @@ class ETHNICITY:
 class SPECIES:
     DOG = "Canis lupus familiaris"
     FLY = "Drosophila melanogaster"
-    HUMAN = "Homo Sapiens"
+    HUMAN = "Homo sapiens"
     MOUSE = "Mus musculus"
 
 


### PR DESCRIPTION
This PR changes the value of `constants.SPECIES.HUMAN` from `"Homo Sapiens"` to `"Homo sapiens"`. I will keep this PR draft until the following issues are resolved:

- Migrate `"Homo Sapiens"` to `"Homo sapiens"` in the `participant` table of the production dataservice postgres backend; and 
- kids-first/kf-api-dataservice#575