### PR TITLE
🔊 Rearrange target ID inquiry to improve load logging

### DIFF
--- a/tests/test_kidsfirst_api_plugin.py
+++ b/tests/test_kidsfirst_api_plugin.py
@@ -19,7 +19,9 @@ def test_external_id_whole_ingest():
     output_dir = join(study_dir, "output")
     delete_dir(output_dir)
     runner.invoke(cli.test, study_dir)
-    with open(join(output_dir, "LoadStage", "SentMessages.json")) as sm:
+    with open(
+        join(output_dir, "LoadStage", "SentMessages_localhost_5000.json")
+    ) as sm:
         data = json.load(sm)
     gfs = [e for e in data if e["type"] == "genomic_file"]
     bsgfs = [e for e in data if e["type"] == "biospecimen_genomic_file"]


### PR DESCRIPTION
Adds a new log message at the end that looks like
```
2021-05-09 22:43:44,002 - LoadStage - Thread: MainThread - INFO - Load Summary:
{'biospecimen': {'ADD': 0, 'UPDATE': 5},
 'biospecimen_genomic_file': {'ADD': 10, 'UPDATE': 0},
 'genomic_file': {'ADD': 0, 'UPDATE': 10},
 'sequencing_experiment': {'ADD': 0, 'UPDATE': 5},
 'sequencing_experiment_genomic_file': {'ADD': 10, 'UPDATE': 0}}
```
etc

Using dry run with a --query_url set will give a summary report for the number of new vs existing entities.