### PR TITLE
✏️ Make hash names lower case & no special characters

### DIFF
--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -30,11 +30,11 @@ class AGE:
 
 class FILE:
     class HASH:
-        MD5 = "MD5"
-        SHA1 = "SHA-1"
-        SHA256 = "SHA-256"
-        SHA512 = "SHA-512"
-        S3_ETAG = "ETag"
+        MD5 = "md5"
+        SHA1 = "sha1"
+        SHA256 = "sha256"
+        SHA512 = "sha512"
+        S3_ETAG = "etag"
 
 
 class SPECIMEN:


### PR DESCRIPTION
To make hash names consistent with what's in the kidsfirst dataservice, make hash names all lower case and without special characters. 

This also means that we no longer have to force etag to be lower case, as in the [template s3_scrape extract config](https://github.com/kids-first/kf-api-study-creator/blob/master/creator/extract_configs/templates/s3_scrape_config.py#L138). 

This also makes values for md5 and sha256 match what's already registered for those values in the hash array, e.g. [GF_N0CKF2WA](https://kf-api-dataservice.kidsfirstdrc.org/genomic-files/GF_N0CKF2WA): 

```json
{
    "hashes": {
        "etag": "e0658c69f26d6540ac111ef055cec933-8077",
        "md5": "3a344aa5e436aee9ddb67e329384b103",
        "sha256": "cba6338f8fc267e86585f7d10a88faaac7b5921a906f805a9be2408a327aa497"
    }
}
```