### PR TITLE
👷‍♀️ Fix CI Errors

### DIFF
--- a/tests/data/simple_study/transform_module_simple.py
+++ b/tests/data/simple_study/transform_module_simple.py
@@ -2,5 +2,4 @@ from kf_lib_data_ingest.config import DEFAULT_KEY
 
 
 def transform_function(mapped_df_dict):
-
     return {DEFAULT_KEY: list(mapped_df_dict.values())[0]}

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -22,7 +22,6 @@ class OAuth2Mocker(object):
         client_secret=TEST_CLIENT_SECRET,
         **mock_kwargs,
     ):
-
         with requests_mock.Mocker() as m:
             self.create_service_token_mock(
                 m,
@@ -50,7 +49,6 @@ class OAuth2Mocker(object):
         client_secret=TEST_CLIENT_SECRET,
         **mock_kwargs,
     ):
-
         with requests_mock.Mocker() as m:
             token_kwargs = {
                 "provider_domain": provider_domain,
@@ -79,7 +77,6 @@ class OAuth2Mocker(object):
         client_secret=TEST_CLIENT_SECRET,
         **mock_kwargs,
     ):
-
         self.create_service_token_mock(
             m,
             provider_domain,
@@ -99,7 +96,6 @@ class OAuth2Mocker(object):
         client_secret=TEST_CLIENT_SECRET,
         **mock_kwargs,
     ):
-
         if not mock_kwargs.get("json"):
             expected_status = mock_kwargs.get("status_code", 200)
             if expected_status == 200:

--- a/tests/test_concept_schema.py
+++ b/tests/test_concept_schema.py
@@ -27,6 +27,7 @@ def test_set_cls_attrs():
     """
     Test method _set_cls_attrs
     """
+
     # Create a class hierarchy
     class Mixin(object):
         COMMON = None

--- a/tests/test_file_retriever.py
+++ b/tests/test_file_retriever.py
@@ -234,7 +234,6 @@ def test_get_web(
 def test_get_web_w_auth(
     caplog, tmpdir, auth_configs, url, auth_type, expected_log
 ):
-
     caplog.set_level(logging.INFO)
     with open(TEST_FILE_PATH, "rb") as tf:
         with requests_mock.Mocker() as m:
@@ -317,7 +316,6 @@ def test_get_web_w_auth(
     ],
 )
 def test_validate_auth_configs(auth_config, expected_exc):
-
     fr = FileRetriever(cleanup_at_exit=True)
     if expected_exc:
         with pytest.raises(expected_exc):

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -98,7 +98,7 @@ def test_bad_token_response(info_caplog):
         TEST_AUTH0_AUD,
         TEST_CLIENT_ID,
         TEST_CLIENT_SECRET,
-        **mock_kwargs
+        **mock_kwargs,
     )
     assert not token
     assert "Unexpected response content" in info_caplog.text


### PR DESCRIPTION
- **Fix lint error**: It's been a while since we've had a PR opened here. The lint check fails bc our `black` formatter finds linter errors. This must be because `black` got stricter with python style
-**Fix doc error**: todo
- **Fix tests error**: todo