### PR TITLE
Add sequencing_experiment fields to target api config and add library_prep and selection to constants

### DIFF
--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -289,6 +289,20 @@ class SEQUENCING:
         RNA = "RNA"
         VIRTUAL = "Virtual"
 
+    class LIBRARY:
+        class SELECTION:
+            HYBRID = "Hybrid Selection"
+            PCR = "PCR"
+            AFFINITY_ENRICHMENT = "Affinity Enrichment"
+            POLYT_ENRICHMENT = "Poly-T Enrichment"
+            RANDOM = "Random"
+            RNA_DEPLETION = "rRNA Depletion"
+            MRNA_SIZE_FRACTIONATION = "miRNA Size Fractionation"
+
+        class PREP:
+            POLYA = "polyA"
+            TOTALRNASEQ = "totalRNAseq"
+
 
 class STUDY:
     CANCER = "Cancer"

--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -141,6 +141,7 @@ class SEQUENCING:
         LS454 = "LS454"
         PACBIO = "PacBio"
         SOLID = "SOLiD"
+        ONT = "ONT"
 
     class INSTRUMENT:
         HISEQ_X_v2_5 = "HiSeq X v2.5"
@@ -149,6 +150,7 @@ class SEQUENCING:
     class STRAND:
         FIRST = "First Stranded"
         SECOND = "Second Stranded"
+        STRANDED = "Stranded"
         UNSTRANDED = "Unstranded"
 
     class CENTER:
@@ -280,6 +282,7 @@ class SEQUENCING:
         WGS = "WGS"
         WXS = "WXS"
         TARGETED = "Targeted Sequencing"
+        PANEL = "Panel"
 
     class ANALYTE:
         DNA = "DNA"

--- a/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
+++ b/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
@@ -604,6 +604,10 @@ class SequencingExperiment:
             "experiment_date": record.get(CONCEPT.SEQUENCING.DATE),
             "experiment_strategy": record.get(CONCEPT.SEQUENCING.STRATEGY),
             "library_strand": record.get(CONCEPT.SEQUENCING.LIBRARY_STRAND),
+            "library_prep": record.get(CONCEPT.SEQUENCING.LIBRARY_PREP),
+            "library_selection": record.get(
+                CONCEPT.SEQUENCING.LIBRARY_SELECTION
+            ),
             "is_paired_end": record.get(CONCEPT.SEQUENCING.PAIRED_END),
             "platform": record.get(CONCEPT.SEQUENCING.PLATFORM),
             "instrument_model": record.get(CONCEPT.SEQUENCING.INSTRUMENT),


### PR DESCRIPTION
# Sequencing Experiment enums

Library prep was not in the target_api_config. I cross referenced the target api config for sequencing experiment with the fields in the sequencing experiment endpoint of the kf dataservice and added library_prep and selection to the target api config. 

I then added [enums](https://github.com/kids-first/kf-api-dataservice/blob/cc47b9e3e5990806e0bf6944d1ec6a3972e84290/dataservice/api/sequencing_experiment/schemas.py#L16-L29) that are declared in the dataservice to the constants.  Drawing specific attention to the addition of `constants.SEQUENCING.PLATFORM.ONT` from @Christina-J-Diaz [for long-reads](https://github.com/kids-first/kf-api-dataservice/pull/599) and the addition of lbrary_prep enums. 
