### PR TITLE
♻️ Replace acl field with new authz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
 
   lint:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.9
     steps:
       - checkout
       - run: |

--- a/kf_lib_data_ingest/app/cli.py
+++ b/kf_lib_data_ingest/app/cli.py
@@ -1,6 +1,7 @@
 """
 Entry point for the Kids First Data Ingest Client
 """
+
 import inspect
 import logging
 import os

--- a/kf_lib_data_ingest/app/settings/__init__.py
+++ b/kf_lib_data_ingest/app/settings/__init__.py
@@ -29,6 +29,7 @@ In `production` mode
 environment variables needed for ingest (i.e. authentication with
 other services)
 """
+
 import os
 
 from kf_lib_data_ingest.common.misc import import_module_from_file

--- a/kf_lib_data_ingest/app/settings/base.py
+++ b/kf_lib_data_ingest/app/settings/base.py
@@ -1,6 +1,7 @@
 """
 Base settings for Kids First Ingest App
 """
+
 import os
 
 from kf_lib_data_ingest.config import ROOT_DIR

--- a/kf_lib_data_ingest/app/settings/development.py
+++ b/kf_lib_data_ingest/app/settings/development.py
@@ -1,6 +1,7 @@
 """
 Development settings for Kids First Ingest App
 """
+
 import os
 
 from kf_lib_data_ingest.app.settings.base import (

--- a/kf_lib_data_ingest/app/settings/production.py
+++ b/kf_lib_data_ingest/app/settings/production.py
@@ -1,6 +1,7 @@
 """
 Production settings for Kids First Ingest App
 """
+
 import os
 
 from kf_lib_data_ingest.app.settings.base import (

--- a/kf_lib_data_ingest/common/io.py
+++ b/kf_lib_data_ingest/common/io.py
@@ -1,6 +1,7 @@
 """
 Contains file readers for file types that benefit from extra help.
 """
+
 import io
 import json
 import os

--- a/kf_lib_data_ingest/common/pandas_utils.py
+++ b/kf_lib_data_ingest/common/pandas_utils.py
@@ -1,6 +1,7 @@
 """
 Utility functions to improve Pandas's rough edges and deficiencies.
 """
+
 import logging
 import re
 from collections import defaultdict

--- a/kf_lib_data_ingest/common/stage.py
+++ b/kf_lib_data_ingest/common/stage.py
@@ -230,6 +230,10 @@ class IngestStage(ABC):
             report_kwargs=report_kwargs,
         )
         if self.validation_success:
-            self.logger.info(f"✅ {self.stage_type.__name__} passed validation!")
+            self.logger.info(
+                f"✅ {self.stage_type.__name__} passed validation!"
+            )
         else:
-            self.logger.info(f"❌ {self.stage_type.__name__} failed validation!")
+            self.logger.info(
+                f"❌ {self.stage_type.__name__} failed validation!"
+            )

--- a/kf_lib_data_ingest/etl/configuration/log.py
+++ b/kf_lib_data_ingest/etl/configuration/log.py
@@ -18,9 +18,9 @@ VERBOTEN_PATTERNS = {
 }
 
 VERBOTEN_PATTERNS['"access_token":".+"'] = '"access_token":"<ACCESS_TOKEN>"'
-VERBOTEN_PATTERNS[
-    "'Authorization': '.+'"
-] = "'Authorization': '<AUTHORIZATION>'"
+VERBOTEN_PATTERNS["'Authorization': '.+'"] = (
+    "'Authorization': '<AUTHORIZATION>'"
+)
 
 
 class NoTokenFormatter(logging.Formatter):

--- a/kf_lib_data_ingest/etl/extract/operations.py
+++ b/kf_lib_data_ingest/etl/extract/operations.py
@@ -12,6 +12,7 @@ its values with other values.
 
 See: docs/design/extract_config_format.py for function details
 """
+
 from pandas import DataFrame
 
 from kf_lib_data_ingest.common.pandas_utils import (  # noqa: F401

--- a/kf_lib_data_ingest/etl/load/load_base.py
+++ b/kf_lib_data_ingest/etl/load/load_base.py
@@ -3,6 +3,7 @@ Module for loading the transform output into the dataservice. It converts the
 merged source data into complete message payloads according to a given API
 specification, and then sends those messages to the target server.
 """
+
 import concurrent.futures
 import json
 import os

--- a/kf_lib_data_ingest/etl/load/load_shim.py
+++ b/kf_lib_data_ingest/etl/load/load_shim.py
@@ -1,4 +1,5 @@
 """Control shim for differentiating load plugin versions."""
+
 from kf_lib_data_ingest.etl.configuration.target_api_config import (
     TargetAPIConfig,
 )

--- a/kf_lib_data_ingest/etl/load/load_v1.py
+++ b/kf_lib_data_ingest/etl/load/load_v1.py
@@ -1,6 +1,7 @@
 """
 For Version 1 Target Service Plugins
 """
+
 from kf_lib_data_ingest.common import constants
 from kf_lib_data_ingest.etl.load.load_base import LoadStageBase
 

--- a/kf_lib_data_ingest/etl/load/load_v2.py
+++ b/kf_lib_data_ingest/etl/load/load_v2.py
@@ -1,6 +1,7 @@
 """
 For Version 2 Target Service Plugins
 """
+
 from pprint import pformat
 
 from kf_lib_data_ingest.common import constants

--- a/kf_lib_data_ingest/etl/transform/guided.py
+++ b/kf_lib_data_ingest/etl/transform/guided.py
@@ -4,6 +4,7 @@ a user supplied transform function which specifies how the mapped
 source data tables should be merged into a single table containing all of the
 mapped source data
 """
+
 import os
 
 import pandas

--- a/kf_lib_data_ingest/etl/transform/transform.py
+++ b/kf_lib_data_ingest/etl/transform/transform.py
@@ -1,6 +1,7 @@
 """
 Module for transforming source data DataFrames to the standard model.
 """
+
 import os
 from abc import abstractmethod
 from pprint import pformat

--- a/kf_lib_data_ingest/network/utils.py
+++ b/kf_lib_data_ingest/network/utils.py
@@ -1,6 +1,7 @@
 """
 Common network (HTTP, TCP, whatever) related functionality
 """
+
 import cgi
 import logging
 import os

--- a/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
+++ b/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
@@ -8,6 +8,7 @@ First Dataservice)
 See etl.configuration.target_api_config docstring for more details on the
 requirements for format and content.
 """
+
 import logging
 from threading import Lock
 

--- a/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
+++ b/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
@@ -563,7 +563,8 @@ class GenomicFile:
             "hashes": hashes(record),
             "size": size(record),
             "urls": str_to_obj(record.get(CONCEPT.GENOMIC_FILE.URL_LIST)),
-            "acl": str_to_obj(record.get(CONCEPT.GENOMIC_FILE.ACL)),
+            "acl": [],
+            "authz": str_to_obj(record.get(CONCEPT.GENOMIC_FILE.ACL)),
             "reference_genome": record.get(
                 CONCEPT.GENOMIC_FILE.REFERENCE_GENOME
             ),

--- a/kf_lib_data_ingest/validation/data_validator.py
+++ b/kf_lib_data_ingest/validation/data_validator.py
@@ -3,6 +3,7 @@ Validation for pre-cleaned data.
 
 Call: Validator(hierarchy_override=None).validate(dict_of_dataframes, include_implicit=True)
 """
+
 import logging
 from collections import defaultdict, deque
 from itertools import combinations

--- a/kf_lib_data_ingest/validation/reporting/base.py
+++ b/kf_lib_data_ingest/validation/reporting/base.py
@@ -1,6 +1,7 @@
 """
 Abstract base class for validation report builders
 """
+
 import logging
 import os
 from abc import ABC, abstractmethod

--- a/kf_lib_data_ingest/validation/reporting/markdown.py
+++ b/kf_lib_data_ingest/validation/reporting/markdown.py
@@ -4,6 +4,7 @@ Produces a human friendly markdown based validation report
 
 Extends kf_lib_data_ingest.validation.reporting.base.AbstractReportBuilder
 """
+
 import os
 import re
 from collections import defaultdict

--- a/kf_lib_data_ingest/validation/reporting/table.py
+++ b/kf_lib_data_ingest/validation/reporting/table.py
@@ -11,6 +11,7 @@ a little bit less nested and verbose
 
 Extends kf_lib_data_ingest.validation.reporting.base.AbstractReportBuilder
 """
+
 import os
 from collections import defaultdict
 

--- a/tests/data/SD_ME0WME0W/ingest_package_config.py
+++ b/tests/data/SD_ME0WME0W/ingest_package_config.py
@@ -1,4 +1,5 @@
 """ Ingest Package Config """
+
 from kf_lib_data_ingest.common.concept_schema import CONCEPT
 
 # The list of entities that will be loaded into the target service

--- a/tests/data/SD_ME0WME0W/transform_module.py
+++ b/tests/data/SD_ME0WME0W/transform_module.py
@@ -7,6 +7,7 @@ See documentation at
 https://kids-first.github.io/kf-lib-data-ingest/ for information on
 implementing transform_function.
 """
+
 import os
 
 # Use these merge funcs, not pandas.merge

--- a/tests/data/kfid_study/ingest_package_config.py
+++ b/tests/data/kfid_study/ingest_package_config.py
@@ -1,4 +1,5 @@
 """ Dataset Ingest Config """
+
 # The list of entities that will be loaded into the target service
 target_service_entities = [
     "genomic_file",

--- a/tests/data/kfid_study/transform_module.py
+++ b/tests/data/kfid_study/transform_module.py
@@ -7,6 +7,7 @@ See documentation at
 https://kids-first.github.io/kf-lib-data-ingest/ for information on
 implementing transform_function.
 """
+
 from kf_lib_data_ingest.config import DEFAULT_KEY
 
 

--- a/tests/data/mock_dataservice_schema.json
+++ b/tests/data/mock_dataservice_schema.json
@@ -945,6 +945,12 @@
                     },
                     "type":"array"
                 },
+                "authz":{
+                    "items":{
+                        "type":"string"
+                    },
+                    "type":"array"
+                },
                 "availability":{
                     "description":"Indicates whether a file is available for immediate download, or is in cold storage",
                     "enum":[

--- a/tests/data/simple_study/ingest_package_config.py
+++ b/tests/data/simple_study/ingest_package_config.py
@@ -1,4 +1,5 @@
 """ Dataset Ingest Config """
+
 from kf_lib_data_ingest.common.concept_schema import CONCEPT
 
 # The list of entities that will be loaded into the target service

--- a/tests/data/simple_study/transform_module.py
+++ b/tests/data/simple_study/transform_module.py
@@ -7,6 +7,7 @@ See documentation at
 https://kids-first.github.io/kf-lib-data-ingest/ for information on
 implementing transform_function.
 """
+
 import os
 
 from kf_lib_data_ingest.config import DEFAULT_KEY

--- a/tests/data/test_study/ingest_package_config.py
+++ b/tests/data/test_study/ingest_package_config.py
@@ -1,4 +1,5 @@
 """ Ingest Package Config """
+
 from kf_lib_data_ingest.common.concept_schema import CONCEPT
 
 # The list of entities that will be loaded into the target service

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -1,6 +1,7 @@
 """
 Tests for kf_lib_data_ingest/common/pandas_utils.py
 """
+
 import numpy
 import pandas
 import pytest


### PR DESCRIPTION
**DO NOT MERGE** until https://github.com/kids-first/kf-api-dataservice/pull/624 is in production

## Motivation

Authorization policy information for indexd files is currently stored in the `acl` list field. However, the `acl` field is being replaced with a new `authz` list field. The values in the `authz` list will correspond to policies created in [Arborist](https://github.com/uc-cdis/arborist). 

The following does not matter too much since the ingest library is not typically used to populate the `acl` field, but putting this here for some context:

- If the `authz` field is populated, any values in the `acl` field are ignored
- If the `authz` field is NOT populated, the values in the `acl` field are used as a fallback
- Because of the above two facts, we should manage the deprecated `acl` conservatively by setting it to an empty list (no access) by default

## Approach

- Add the new `authz` field to the KF dataservice target API plugin
- Set the value of `acl` field in KF dataservice target API plugin to be an empty list
