### PR TITLE
:heavy_plus_sign: add new constants for LRs

### DIFF
--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -301,6 +301,11 @@ class SEQUENCING:
         PANEL = "Panel"
         SCRNA = "scRNA-Seq"
         SNRNA = "snRNA-Seq"
+        CCS_WGS = "Circular Consensus Sequencing WGS"
+        CCS_RNA = "Circular Consensus Sequencing RNA-Seq"
+        CLR_WGS = "Continuous Long Reads WGS"
+        CLR_RNA = "Continuous Long Reads RNA-Seq"
+        ONT_WGS = "ONT WGS"
 
     class ANALYTE:
         DNA = "DNA"
@@ -316,8 +321,6 @@ class SEQUENCING:
             RANDOM = "Random"
             RNA_DEPLETION = "rRNA Depletion"
             MRNA_SIZE_FRACTIONATION = "miRNA Size Fractionation"
-            CLR = "Continuous Long Reads"
-            CCS = "Circular Consensus Sequencing"
 
         class PREP:
             POLYA = "polyA"

--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -316,6 +316,8 @@ class SEQUENCING:
             RANDOM = "Random"
             RNA_DEPLETION = "rRNA Depletion"
             MRNA_SIZE_FRACTIONATION = "miRNA Size Fractionation"
+            CLR = "Continuous Long Reads"
+            CCS = "Circular Consensus Sequencing"
 
         class PREP:
             POLYA = "polyA"


### PR DESCRIPTION
For long reads sequencing, the `se.library_selection` field should be set to either CCS or CLR.

- circular consensus sequencing (CCS)

- continuous long reads (CLR)

These values should be added as constants in the ingest library so that they will be accepted during long reads ingest. cc: @HigginsD3b 