### PR TITLE
:memo: add Variantyx sequencer

### DIFF
--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -282,6 +282,10 @@ class SEQUENCING:
             NAME = "UNKNOWN:CHRIS_JONES"
             KF_ID = "SC_5A2B1T4K"
 
+        class VARIANTYX:
+            NAME = "Variantyx"
+            KF_ID = "SC_T2A19FHX"
+
         class VIRTUAL:
             NAME = "Virtual"
             KF_ID = "SC_BATJDPHB"


### PR DESCRIPTION
Add the `Variantyx` center

`{"_links":{"biospecimens":"/biospecimens?sequencing_center_id=SC_T2A19FHX","collection":"/sequencing-centers","self":"/sequencing-centers/SC_T2A19FHX","sequencing_experiments":"/sequencing-experiments?sequencing_center_id=SC_T2A19FHX"},"_status":{"code":201,"message":"sequencing_center SC_T2A19FHX created"},"results":{"created_at":"2024-04-26T03:26:33.921674+00:00","external_id":null,"kf_id":"SC_T2A19FHX","modified_at":"2024-04-26T03:26:33.921682+00:00","name":"Variantyx","visibility_comment":null,"visibility_reason":null,"visible":true}}`