### PR TITLE
🚑️ Fix typo in kf target_api_plugin

### DIFF
--- a/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
+++ b/kf_lib_data_ingest/target_api_plugins/kids_first_dataservice.py
@@ -757,8 +757,8 @@ class GenomicFile:
             "reference_genome": record.get(
                 CONCEPT.GENOMIC_FILE.REFERENCE_GENOME
             ),
-            "worflow_type": record.get(CONCEPT.GENOMIC_FILE.WORKFLOW_TYPE),
-            "worflow_tool": record.get(CONCEPT.GENOMIC_FILE.WORKFLOW_TOOL),
+            "workflow_type": record.get(CONCEPT.GENOMIC_FILE.WORKFLOW_TYPE),
+            "workflow_tool": record.get(CONCEPT.GENOMIC_FILE.WORKFLOW_TOOL),
             "workflow_version": record.get(
                 CONCEPT.GENOMIC_FILE.WORKFLOW_VERSION
             ),


### PR DESCRIPTION
workflow_tool and workflow_type are misspelled

See [D3B-723](https://d3b.atlassian.net/browse/D3B-723)

[D3B-723]: https://d3b.atlassian.net/browse/D3B-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ