### PR TITLE
:necktie: add upenn

### DIFF
--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -287,7 +287,7 @@ class SEQUENCING:
             KF_ID = "SC_MSQP04K7"
 
         class UPENN:
-            NAME = "University of Penn"
+            NAME = "University of Pennsylvania"
             KF_ID = "SC_K20D8V6F"
 
         class VARIANTYX:

--- a/kf_lib_data_ingest/common/constants.py
+++ b/kf_lib_data_ingest/common/constants.py
@@ -286,6 +286,10 @@ class SEQUENCING:
             NAME = "UCSF CAT"
             KF_ID = "SC_MSQP04K7"
 
+        class UPENN:
+            NAME = "University of Penn"
+            KF_ID = "SC_K20D8V6F"
+
         class VARIANTYX:
             NAME = "Variantyx"
             KF_ID = "SC_T2A19FHX"


### PR DESCRIPTION
Add the `Upenn` as sequencing center

`{"_links":{"biospecimens":"/biospecimens?sequencing_center_id=SC_K20D8V6F","collection":"/sequencing-centers","self":"/sequencing-centers/SC_K20D8V6F","sequencing_experiments":"/sequencing-experiments?sequencing_center_id=SC_K20D8V6F"},"_status":{"code":201,"message":"sequencing_center SC_K20D8V6F created"},"results":{"created_at":"2024-11-07T14:23:09.092805+00:00","external_id":null,"kf_id":"SC_K20D8V6F","modified_at":"2024-11-07T14:23:09.092814+00:00","name":"University of Penn","visibility_comment":null,"visibility_reason":null,"visible":true}}`