### PR TITLE
Fix safe_pandas_replace dropping identity mappings

### DIFF
--- a/kf_lib_data_ingest/common/pandas_utils.py
+++ b/kf_lib_data_ingest/common/pandas_utils.py
@@ -260,16 +260,29 @@ def safe_pandas_replace(data, mappings, regex=False):
                     k = "^(" + k[1:-1] + ")$"
                     matches = data.str.extract(k)
 
+                # A cell matched this pattern iff str.extract produced a
+                # non-null capture for it.
+                matched = pandas.notnull(matches[0])
+
                 new = data.copy()
                 # create new values using the returns from the function calls
-                new[pandas.notnull(matches[0])] = matches.astype(str).apply(
+                new[matched] = matches.astype(str).apply(
                     lambda row: v(*row), axis=1
                 )
             else:  # basic replacement
                 new = data.replace({k: v}, regex=True)
+                # A cell matched this pattern iff the (anchored) pattern
+                # matches the cell's string value.
+                matched = data.astype(str).str.match(k)
 
-            # Fill only the remaining holes with new values
-            output[holes] = new[new.astype(str) != data.astype(str)][holes]
+            # Claim every still-empty hole that this pattern matched, even
+            # when the replacement value equals the original value (an
+            # identity mapping such as "White" -> "White"). Keying off "the
+            # pattern matched" rather than "the value changed" is what stops
+            # a later mapping (e.g. a catch-all r".*") from silently
+            # overriding a literal match whose value happened to be unchanged.
+            fill = holes & matched.fillna(False)
+            output[fill] = new[fill]
 
         # Fill any remaining holes with original values
         holes = output.apply(lambda x: x is numpy.nan)

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -60,6 +60,93 @@ def test_safe_pandas_replace_no_cascade():
     ).equals(pandas.Series(["2", "3", "4"]))
 
 
+def test_safe_pandas_replace_non_cascade_on_created_values():
+    # A value created by an earlier mapping must not be re-mapped by a later
+    # one. Mapping "1" -> "2" creates a "2", but the later "2" -> "9" mapping
+    # should only touch the *original* "2".
+    assert pandas_utils.safe_pandas_replace(
+        pandas.Series(["1", "2"]), {"1": "2", "2": "9"}
+    ).equals(pandas.Series(["2", "9"]))
+
+
+def test_safe_pandas_replace_identity_mapping_survives_catchall():
+    # Regression test: an identity mapping (original == replacement) must
+    # still "claim" the cells it matches so that a later catch-all does not
+    # silently override them. Previously the function decided which cells a
+    # mapping had claimed by checking whether the value *changed*, so an
+    # identity mapping claimed nothing and the catch-all clobbered it.
+    mappings = {
+        "A": "A",  # identity mapping -- value does not change
+        r".*": "X",  # catch-all applied to whatever is left
+    }
+    # on a series
+    assert pandas_utils.safe_pandas_replace(
+        pandas.Series(["A", "B"]), mappings, regex=True
+    ).equals(pandas.Series(["A", "X"]))
+
+    # multiple identity mappings followed by a catch-all (the shape that
+    # corrupted race / ethnicity / tissue-type fields in SD_2Z0N3FB6)
+    multi = {
+        "White": "White",
+        "Asian": "Asian",
+        r".*": "Not Reported",
+    }
+    assert pandas_utils.safe_pandas_replace(
+        pandas.Series(["White", "Asian", "Other", "White"]), multi, regex=True
+    ).equals(pandas.Series(["White", "Asian", "Not Reported", "White"]))
+
+
+def test_safe_pandas_replace_identity_mapping_dataframe_column_map():
+    # Same regression, exercised through the DataFrame / column-specific path.
+    df = pandas.DataFrame({"race": ["White", "Black", "Other"]})
+    mappings = {
+        "race": {
+            "White": "White",
+            "Black": "Black",
+            r".*": "Not Reported",
+        }
+    }
+    assert pandas_utils.safe_pandas_replace(df, mappings, regex=True).equals(
+        pandas.DataFrame({"race": ["White", "Black", "Not Reported"]})
+    )
+
+
+def test_safe_pandas_replace_non_identity_still_cascades_into_catchall():
+    # Guard the converse: a genuinely-changed value is claimed by its mapping,
+    # and only truly unmatched cells fall through to the catch-all.
+    assert pandas_utils.safe_pandas_replace(
+        pandas.Series(["A", "B"]), {"A": "Z", r".*": "X"}, regex=True
+    ).equals(pandas.Series(["Z", "X"]))
+
+
+def test_safe_pandas_replace_callable():
+    # A callable replacement receives the regex capture(s) and its result
+    # replaces the matched cell.
+    assert pandas_utils.safe_pandas_replace(
+        pandas.Series(["x1", "x2"]), {r"x(\d)": lambda d: "n" + d}, regex=True
+    ).equals(pandas.Series(["n1", "n2"]))
+
+
+def test_safe_pandas_replace_callable_identity_survives_catchall():
+    # The same identity-mapping bug existed in the callable branch: a callable
+    # that returns the original value produced no change and so was dropped,
+    # letting the catch-all override it.
+    assert pandas_utils.safe_pandas_replace(
+        pandas.Series(["keep", "drop"]),
+        {r"keep": lambda m: "keep", r".*": "X"},
+        regex=True,
+    ).equals(pandas.Series(["keep", "X"]))
+
+
+def test_safe_pandas_replace_catchall_first_claims_everything():
+    # Documented non-cascade behavior is order-sensitive: a catch-all placed
+    # first claims every cell, so a later literal never gets a turn. This is
+    # intentional and must remain stable.
+    assert pandas_utils.safe_pandas_replace(
+        pandas.Series(["A", "B"]), {r".*": "X", "A": "A"}, regex=True
+    ).equals(pandas.Series(["X", "X"]))
+
+
 def test_merge_wo_duplicates(info_caplog, dfs):
     df1 = dfs[0]
     df2 = dfs[0].copy()


### PR DESCRIPTION
# Fix `safe_pandas_replace` dropping identity mappings

Fixes #710

## Problem

`safe_pandas_replace` decided which cells a mapping had claimed by checking
whether the replacement **changed the value**:

```python
output[holes] = new[new.astype(str) != data.astype(str)][holes]
```

For an **identity mapping** (source value equals replacement, e.g.
`"White" -> "White"`), nothing changes, so the matched cell was never claimed
and stayed an unfilled hole. The next mapping in the dict — typically a `r".*"`
catch-all — then filled it, silently overriding the literal match.

This corrupted `source_text_tissue_type`, `race`, and `ethnicity` across all 573
biospecimens in the SD_2Z0N3FB6 (Craniosynostosis) PROD ingest, where each field
was loaded as `"Not Reported"`.

The callable-replacement branch had the same defect: a callable returning the
original value produced no change and was likewise dropped.

## Fix

Claim a hole when the (anchored) pattern **matches** the cell, not when the value
changes:

- Non-callable branch: derive the match mask from
  `data.astype(str).str.match(k)` (the same anchored pattern already used for
  replacement).
- Callable branch: reuse the existing non-null capture mask
  `pandas.notnull(matches[0])`.

Holes are then filled with `fill = holes & matched`, so an identity match still
protects its cell from later mappings while genuinely unmatched cells continue to
fall through to the catch-all. Non-cascade semantics are unchanged: matching is
always evaluated against the original input, never against already-written
output.

## Tests

Added to `tests/test_pandas_utils.py`:

- identity mapping survives a catch-all (Series, and the multi-identity
  craniosynostosis shape)
- identity mapping survives a catch-all through the DataFrame column-map path
- callable identity mapping survives a catch-all
- non-identity mappings still resolve correctly alongside a catch-all
- a value created by one mapping is not re-mapped by a later one (non-cascade)
- a catch-all placed first still claims every cell (documented, order-sensitive
  behavior — left intact)

The three identity/callable tests fail on `main` and pass with this change; the
existing `test_safe_pandas_replace_no_cascade` and the new guard tests pass on
both. Verified on pandas 2.2.3; the change uses only APIs available on the
pinned `pandas>=1.1,<1.3` / Python 3.7–3.8 CI matrix
(`pandas.notnull`, `Series.str.match`, `Series.fillna`, boolean indexing).

## Out of scope (noted for awareness)

When a *column-specific* map and a *global* (non-column) catch-all are combined
in the same call, the global catch-all is applied as a separate pass over the
already-mapped column output and will re-map it (including non-identity values).
That is a property of the existing column/global composition, independent of this
bug, and is unchanged here.

## Context

Third upstream contribution arising from SD_2Z0N3FB6, alongside
`FamilyRelationship.submit` and `GenomicFile.query_target_ids`.
